### PR TITLE
Replace CSS Parser

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
 		  <version>6.5.0</version>
 		</dependency>
 
-		<!-- FIXME -->
+		<!-- FIXME REMOVE -->
 		<dependency>
 			<groupId>com.osbcp</groupId>
 			<artifactId>cssparser</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,12 @@
 		    <version>2.3</version>
 		</dependency>
 		
+		<dependency>
+		  <groupId>com.helger</groupId>
+		  <artifactId>ph-css</artifactId>
+		  <version>6.5.0</version>
+		</dependency>
+
 		<!-- FIXME -->
 		<dependency>
 			<groupId>com.osbcp</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>uk.co.certait</groupId>
@@ -70,9 +71,9 @@
 			<version>2.11.0</version>
 		</dependency>
 		<dependency>
-		    <groupId>org.apache.commons</groupId>
-		    <artifactId>commons-text</artifactId>
-		    <version>1.9</version>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-text</artifactId>
+			<version>1.9</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>
@@ -85,24 +86,16 @@
 			<version>9.1.22</version>
 		</dependency>
 		<dependency>
-		    <groupId>org.apache.velocity</groupId>
-		    <artifactId>velocity-engine-core</artifactId>
-		    <version>2.3</version>
-		</dependency>
-		
-		<dependency>
-		  <groupId>com.helger</groupId>
-		  <artifactId>ph-css</artifactId>
-		  <version>6.5.0</version>
+			<groupId>org.apache.velocity</groupId>
+			<artifactId>velocity-engine-core</artifactId>
+			<version>2.3</version>
 		</dependency>
 
-		<!-- FIXME REMOVE -->
 		<dependency>
-			<groupId>com.osbcp</groupId>
-			<artifactId>cssparser</artifactId>
-			<version>1.0.1</version>
+			<groupId>com.helger</groupId>
+			<artifactId>ph-css</artifactId>
+			<version>6.5.0</version>
 		</dependency>
-		
 
 		<!-- FIXME -->
 		<dependency>
@@ -111,6 +104,13 @@
 			<version>0.7-incubating</version>
 		</dependency>
 		
+		<!-- LOGGING -->
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<version>1.2.11</version>
+		</dependency>
+	
 		<!-- TEST ONLY -->
 		<dependency>
 			<groupId>junit</groupId>
@@ -124,6 +124,13 @@
 			<version>3.1</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<version>3.22.0</version>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 
 	<build>
@@ -150,22 +157,10 @@
 					</execution>
 				</executions>
 			</plugin>
-<!-- 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>attach-javadocs</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
-						Prevents errors stopping build in java 8
-			            <configuration>
-			                <additionalparam>-Xdoclint:none</additionalparam>
-			            </configuration>
-					</execution>
-				</executions>
-			</plugin> -->
+			<!-- <plugin> <groupId>org.apache.maven.plugins</groupId> <artifactId>maven-javadoc-plugin</artifactId> 
+				<executions> <execution> <id>attach-javadocs</id> <goals> <goal>jar</goal> 
+				</goals> Prevents errors stopping build in java 8 <configuration> <additionalparam>-Xdoclint:none</additionalparam> 
+				</configuration> </execution> </executions> </plugin> -->
 			<plugin>
 				<groupId>com.mycila.maven-license-plugin</groupId>
 				<artifactId>maven-license-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,12 @@
 			<artifactId>logback-classic</artifactId>
 			<version>1.2.11</version>
 		</dependency>
+		<dependency>
+		    <groupId>org.apache.logging.log4j</groupId>
+		    <artifactId>log4j-core</artifactId>
+		    <version>2.17.2</version>
+		</dependency>
+
 	
 		<!-- TEST ONLY -->
 		<dependency>

--- a/src/main/java/uk/co/certait/htmlexporter/css/CssColorProperty.java
+++ b/src/main/java/uk/co/certait/htmlexporter/css/CssColorProperty.java
@@ -16,7 +16,7 @@
 package uk.co.certait.htmlexporter.css;
 
 public enum CssColorProperty {
-	COLOR("color"), BACKGROUND("background"), BACKGROUND_COLOR("background-color"), BORDER_COLOR("border-color"),
+	COLOR("color"), BACKGROUND_COLOR("background-color"), BORDER_COLOR("border-color"),
 	BORDER_TOP_COLOR("border-top-color"), BORDER_BOTTOM_COLOR("border-bottom-color"),
 	BORDER_LEFT_COLOR("border-left-color"), BORDER_RIGHT_COLOR("border-right-color");
 

--- a/src/main/java/uk/co/certait/htmlexporter/css/CssColorProperty.java
+++ b/src/main/java/uk/co/certait/htmlexporter/css/CssColorProperty.java
@@ -16,7 +16,9 @@
 package uk.co.certait.htmlexporter.css;
 
 public enum CssColorProperty {
-	COLOR("color"), BACKGROUND("background"), BORDER_COLOR("border-color");
+	COLOR("color"), BACKGROUND("background"), BACKGROUND_COLOR("background-color"), BORDER_COLOR("border-color"),
+	BORDER_TOP_COLOR("border-top-color"), BORDER_BOTTOM_COLOR("border-bottom-color"),
+	BORDER_LEFT_COLOR("border-left-color"), BORDER_RIGHT_COLOR("border-right-color");
 
 	private String property;
 

--- a/src/main/java/uk/co/certait/htmlexporter/css/CssStringProperty.java
+++ b/src/main/java/uk/co/certait/htmlexporter/css/CssStringProperty.java
@@ -16,8 +16,10 @@
 package uk.co.certait.htmlexporter.css;
 
 public enum CssStringProperty {
-	FONT_FAMILY("font-family"), FONT_WEIGHT("font-weight"), FONT_STYLE("font-style"), TEXT_DECORATION("text-decoration"), TEXT_ALIGN(
-			"text-align"), VERTICAL_ALIGN("vertical-align");
+	FONT_FAMILY("font-family"), FONT_WEIGHT("font-weight"), FONT_STYLE("font-style"),
+	TEXT_DECORATION("text-decoration"), TEXT_ALIGN("text-align"), VERTICAL_ALIGN("vertical-align"),
+	BORDER_STYLE("border-style"), BORDER_TOP_STYLE("border-top-style"), BORDER_BOTTOM_STYLE("border-bottom-style"),
+	BORDER_LEFT_STYLE("border-left-style"), BORDER_RIGHT_STYLE("border-right-style");
 
 	private String property;
 

--- a/src/main/java/uk/co/certait/htmlexporter/css/Style.java
+++ b/src/main/java/uk/co/certait/htmlexporter/css/Style.java
@@ -38,6 +38,10 @@ public class Style {
 	protected static final String TOP_ALIGN = "top";
 	protected static final String BOTTOM_ALIGN = "bottom";
 	protected static final String MIDDLE_ALIGN = "middle";
+	protected static final String SOLID_BORDER = "solid";
+	protected static final String DASHED_BORDER = "dashed";
+	protected static final String DOTTED_BORDER = "dotted";
+	protected static final String DOUBLE_BORDER = "double";
 
 	private Map<CssIntegerProperty, Integer> integerProperties;
 	private Map<CssStringProperty, String> stringProperties;

--- a/src/main/java/uk/co/certait/htmlexporter/css/Style.java
+++ b/src/main/java/uk/co/certait/htmlexporter/css/Style.java
@@ -148,7 +148,7 @@ public class Style {
 	}
 
 	public boolean isBackgroundSet() {
-		return colorProperties.containsKey(CssColorProperty.BACKGROUND);
+		return colorProperties.containsKey(CssColorProperty.BACKGROUND_COLOR);
 	}
 
 	public boolean isBorderColorSet() {

--- a/src/main/java/uk/co/certait/htmlexporter/css/StyleMap.java
+++ b/src/main/java/uk/co/certait/htmlexporter/css/StyleMap.java
@@ -23,8 +23,11 @@ import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 import org.jsoup.nodes.Element;
 
-import com.osbcp.cssparser.CSSParser;
-import com.osbcp.cssparser.Rule;
+import com.helger.commons.collection.impl.ICommonsList;
+import com.helger.css.ECSSVersion;
+import com.helger.css.decl.CSSDeclaration;
+import com.helger.css.decl.CSSDeclarationList;
+import com.helger.css.reader.CSSReaderDeclarationList;
 
 /**
  * 
@@ -86,22 +89,31 @@ public class StyleMap {
 		return classStyles;
 	}
 
-	private Style getInlineStyle(Element element) {
-		Style style = null;
+	protected Style getInlineStyle(Element element) {
+		List<Style> styles = new ArrayList<>();
 
 		if (element.hasAttr("style")) {
-			List<Rule> inlineRules;
-			try {
-				String inlineStyle = element.attr("style").endsWith(";") ? element.attr("style") : element
-						.attr("style") + ";";
-				inlineRules = CSSParser.parse("x{" + inlineStyle + "}");
-			} catch (Exception e) {
-				throw new RuntimeException("Error parsing inline style for element " + element.tagName());
+			/*
+			 * List<Rule> inlineRules; try { String inlineStyle =
+			 * element.attr("style").endsWith(";") ? element.attr("style") : element
+			 * .attr("style") + ";"; inlineRules = CSSParser.parse("x{" + inlineStyle +
+			 * "}"); } catch (Exception e) { throw new
+			 * RuntimeException("Error parsing inline style for element " +
+			 * element.tagName()); }
+			 */
+
+			CSSDeclarationList cssStyles = CSSReaderDeclarationList.readFromString(element.attr("style"),
+					ECSSVersion.LATEST);
+			ICommonsList<CSSDeclaration> declarations = cssStyles.getAllDeclarations();
+
+			for (CSSDeclaration declaration : declarations) {
+				styles.add(generator.createStyle(declaration));
 			}
 
-			style = generator.createStyle(inlineRules.get(0), inlineRules.get(0).getSelectors().get(0));
+			// style = generator.createStyle(inlineRules.get(0),
+			// inlineRules.get(0).getSelectors().get(0));
 		}
 
-		return style;
+		return StyleMerger.mergeStyles(styles.toArray(new Style[0]));
 	}
 }

--- a/src/main/java/uk/co/certait/htmlexporter/css/StyleMap.java
+++ b/src/main/java/uk/co/certait/htmlexporter/css/StyleMap.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
 import org.jsoup.nodes.Element;
@@ -60,8 +61,10 @@ public class StyleMap {
 			}
 		}
 
-		if (getInlineStyle(element) != null) {
-			style = StyleMerger.mergeStyles(style, getInlineStyle(element));
+		Optional<Style> inlineStyle = getInlineStyle(element);
+		
+		if (inlineStyle.isPresent()) {
+			style = StyleMerger.mergeStyles(style, inlineStyle.get());
 		}
 
 		return style;
@@ -89,7 +92,7 @@ public class StyleMap {
 		return classStyles;
 	}
 
-	protected Style getInlineStyle(Element element) {
+	protected Optional<Style> getInlineStyle(Element element) {
 		List<Style> styles = new ArrayList<>();
 
 		if (element.hasAttr("style")) {
@@ -114,6 +117,6 @@ public class StyleMap {
 			// inlineRules.get(0).getSelectors().get(0));
 		}
 
-		return StyleMerger.mergeStyles(styles.toArray(new Style[0]));
+		return Optional.of(StyleMerger.mergeStyles(styles.toArray(new Style[0])));
 	}
 }

--- a/src/main/java/uk/co/certait/htmlexporter/writer/AbstractExporter.java
+++ b/src/main/java/uk/co/certait/htmlexporter/writer/AbstractExporter.java
@@ -58,7 +58,7 @@ public abstract class AbstractExporter implements Exporter {
 																// twice
 
 		StyleParser parser = new StyleParser();
-		StyleMap mapper = new StyleMap(parser.parseStyles(styles));
+		StyleMap mapper = new StyleMap(parser.parseStyleSheet(styles.get(0))); //FIXME SUPPORT MULTIPLE
 
 		return mapper;
 	}

--- a/src/main/java/uk/co/certait/htmlexporter/writer/excel/ExcelStyleGenerator.java
+++ b/src/main/java/uk/co/certait/htmlexporter/writer/excel/ExcelStyleGenerator.java
@@ -67,27 +67,68 @@ public class ExcelStyleGenerator {
 	protected void applyBackground(Style style, XSSFCellStyle cellStyle) {
 		if (style.isBackgroundSet()) {
 			cellStyle.setFillPattern(FillPatternType.SOLID_FOREGROUND);
-			cellStyle.setFillForegroundColor(new XSSFColor(style.getProperty(CssColorProperty.BACKGROUND), null));
+			cellStyle.setFillForegroundColor(new XSSFColor(style.getProperty(CssColorProperty.BACKGROUND_COLOR), null));
 		}
 	}
 
 	protected void applyBorders(Style style, XSSFCellStyle cellStyle) {
 		if (style.isBorderWidthSet()) {
 
-			Color color = style.getProperty(CssColorProperty.BORDER_COLOR) != null ? style
-					.getProperty(CssColorProperty.BORDER_COLOR) : Color.BLACK;
+			Color borderColor = style.getProperty(CssColorProperty.BORDER_COLOR) != null
+					? style.getProperty(CssColorProperty.BORDER_COLOR)
+					: Color.BLACK;
 
-			cellStyle.setBorderBottom(BorderStyle.THIN);
-			cellStyle.setBottomBorderColor(new XSSFColor(color, null));
+			Color topBorderColor = style.getProperty(CssColorProperty.BORDER_TOP_COLOR) != null
+					? style.getProperty(CssColorProperty.BORDER_TOP_COLOR)
+					: borderColor;
 
-			cellStyle.setBorderTop(BorderStyle.THIN);
-			cellStyle.setTopBorderColor(new XSSFColor(color, null));
+			Color bottomBorderColor = style.getProperty(CssColorProperty.BORDER_BOTTOM_COLOR) != null
+					? style.getProperty(CssColorProperty.BORDER_BOTTOM_COLOR)
+					: borderColor;
 
-			cellStyle.setBorderLeft(BorderStyle.THIN);
-			cellStyle.setLeftBorderColor(new XSSFColor(color, null));
+			Color leftBorderColor = style.getProperty(CssColorProperty.BORDER_LEFT_COLOR) != null
+					? style.getProperty(CssColorProperty.BORDER_LEFT_COLOR)
+					: borderColor;
 
-			cellStyle.setBorderRight(BorderStyle.THIN);
-			cellStyle.setRightBorderColor(new XSSFColor(color, null));
+			Color rightBorderColor = style.getProperty(CssColorProperty.BORDER_RIGHT_COLOR) != null
+					? style.getProperty(CssColorProperty.BORDER_RIGHT_COLOR)
+					: borderColor;
+
+			String borderStyle = style.getProperty(CssStringProperty.BORDER_STYLE);
+
+			String topBorderStyle = style.getProperty(CssStringProperty.BORDER_TOP_STYLE) != null
+					? style.getProperty(CssStringProperty.BORDER_TOP_STYLE)
+					: borderStyle;
+
+			String bottomBorderStyle = style.getProperty(CssStringProperty.BORDER_BOTTOM_STYLE) != null
+					? style.getProperty(CssStringProperty.BORDER_BOTTOM_STYLE)
+					: borderStyle;
+
+			String leftBorderStyle = style.getProperty(CssStringProperty.BORDER_LEFT_STYLE) != null
+					? style.getProperty(CssStringProperty.BORDER_LEFT_STYLE)
+					: borderStyle;
+
+			String rightBorderStyle = style.getProperty(CssStringProperty.BORDER_RIGHT_STYLE) != null
+					? style.getProperty(CssStringProperty.BORDER_RIGHT_STYLE)
+					: borderStyle;
+
+			String solidBorder = "solid";
+
+			cellStyle.setBorderTop(topBorderStyle.equals(solidBorder) ? BorderStyle.THIN
+					: BorderStyle.valueOf(topBorderStyle.toUpperCase()));
+			cellStyle.setTopBorderColor(new XSSFColor(topBorderColor, null));
+
+			cellStyle.setBorderBottom(bottomBorderStyle.equals(solidBorder) ? BorderStyle.THIN
+					: BorderStyle.valueOf(bottomBorderStyle.toUpperCase()));
+			cellStyle.setBottomBorderColor(new XSSFColor(bottomBorderColor, null));
+
+			cellStyle.setBorderLeft(leftBorderStyle.equals(solidBorder) ? BorderStyle.THIN
+					: BorderStyle.valueOf(leftBorderStyle.toUpperCase()));
+			cellStyle.setLeftBorderColor(new XSSFColor(leftBorderColor, null));
+
+			cellStyle.setBorderRight(rightBorderStyle.equals(solidBorder) ? BorderStyle.THIN
+					: BorderStyle.valueOf(rightBorderStyle.toUpperCase()));
+			cellStyle.setRightBorderColor(new XSSFColor(rightBorderColor, null));
 		}
 	}
 

--- a/src/main/java/uk/co/certait/htmlexporter/writer/ods/OdsStyleGenerator.java
+++ b/src/main/java/uk/co/certait/htmlexporter/writer/ods/OdsStyleGenerator.java
@@ -33,7 +33,7 @@ import uk.co.certait.htmlexporter.css.Style;
 public class OdsStyleGenerator {
 	public void styleCell(Cell cell, Style style) {
 		if (style.isBackgroundSet()) {
-			cell.setCellBackgroundColor(new Color(style.getProperty(CssColorProperty.BACKGROUND)));
+			cell.setCellBackgroundColor(new Color(style.getProperty(CssColorProperty.BACKGROUND_COLOR)));
 		}
 
 		applyBorder(cell, style);

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,18 @@
+<configuration>
+
+	<appender name="STDOUT"
+		class="ch.qos.logback.core.ConsoleAppender">
+		<!-- encoders are assigned the type ch.qos.logback.classic.encoder.PatternLayoutEncoder 
+			by default -->
+		<encoder>
+			<pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n
+			</pattern>
+		</encoder>
+	</appender>
+
+	<logger name="com.helger" level="WARN" />
+
+	<root level="debug">
+		<appender-ref ref="STDOUT" />
+	</root>
+</configuration>

--- a/src/main/resources/report.css
+++ b/src/main/resources/report.css
@@ -11,9 +11,7 @@
 	
 	th, td{
 		font-family: sans-serif;
-		border-color: #000000;
-		border-width: 1px;
-		border-style: solid;
+		border: 1px solid #000000;
 		padding-left: 2px;
 		padding-right: 2px;
 	}

--- a/src/test/java/uk/co/certait/htmlexporter/css/StyleMapTest.java
+++ b/src/test/java/uk/co/certait/htmlexporter/css/StyleMapTest.java
@@ -17,6 +17,9 @@ package uk.co.certait.htmlexporter.css;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.awt.Color;
+import java.util.Optional;
+
 import org.jsoup.nodes.Element;
 import org.jsoup.parser.Tag;
 import org.junit.Test;
@@ -26,20 +29,26 @@ public class StyleMapTest {
 	@Test
 	public void testGetInlineStyle() {
 		Element e = new Element(Tag.valueOf("td"), "") {
-			
+
 			@Override
 			public boolean hasAttr(String attributeKey) {
 				return true;
 			}
+
 			@Override
 			public String attr(String attributeKey) {
-				return "font-color: red; background: white; border: 1px dashed #678876";
+				return "color: red; background: white; border: 2px dashed #678876";
 			}
 		};
 
-		Style style = new StyleMap(null).getInlineStyle(e);
+		Optional<Style> optional = new StyleMap(null).getInlineStyle(e);
+		assertThat(optional).isPresent();
+		Style style = optional.get();
 
-		// FIXME Use Optional
-		assertThat(style).isNotNull();
+		assertThat(style.getProperty(CssColorProperty.COLOR)).isEqualTo(Color.RED);
+		assertThat(style.getProperty(CssColorProperty.BACKGROUND_COLOR)).isEqualTo(Color.WHITE);
+		assertThat(style.getProperty(CssIntegerProperty.BORDER_WIDTH)).isEqualTo(2);
+		assertThat(style.getProperty(CssStringProperty.BORDER_STYLE)).isEqualTo(Style.DASHED_BORDER);
+		assertThat(style.getProperty(CssColorProperty.BORDER_COLOR)).isEqualTo(Color.decode("#678876"));
 	}
 }

--- a/src/test/java/uk/co/certait/htmlexporter/css/StyleMapTest.java
+++ b/src/test/java/uk/co/certait/htmlexporter/css/StyleMapTest.java
@@ -15,6 +15,31 @@
  */
 package uk.co.certait.htmlexporter.css;
 
-public class StyleMapperTest {
+import static org.assertj.core.api.Assertions.assertThat;
 
+import org.jsoup.nodes.Element;
+import org.jsoup.parser.Tag;
+import org.junit.Test;
+
+public class StyleMapTest {
+
+	@Test
+	public void testGetInlineStyle() {
+		Element e = new Element(Tag.valueOf("td"), "") {
+			
+			@Override
+			public boolean hasAttr(String attributeKey) {
+				return true;
+			}
+			@Override
+			public String attr(String attributeKey) {
+				return "font-color: red; background: white; border: 1px dashed #678876";
+			}
+		};
+
+		Style style = new StyleMap(null).getInlineStyle(e);
+
+		// FIXME Use Optional
+		assertThat(style).isNotNull();
+	}
 }

--- a/src/test/java/uk/co/certait/htmlexporter/css/StyleMergerTest.java
+++ b/src/test/java/uk/co/certait/htmlexporter/css/StyleMergerTest.java
@@ -27,12 +27,12 @@ public class StyleMergerTest {
 		Style classStyle = new Style();
 		Style inlineStyle = new Style();
 
-		tagStyle.addProperty(CssColorProperty.BACKGROUND, Color.RED);
+		tagStyle.addProperty(CssColorProperty.BACKGROUND_COLOR, Color.RED);
 		tagStyle.addProperty(CssStringProperty.FONT_WEIGHT, Style.BOLD_FONT_STYLE);
 
 		classStyle.addProperty(CssIntegerProperty.BORDER_WIDTH, 3);
 		classStyle.addProperty(CssStringProperty.FONT_STYLE, Style.TEXT_DECORATION_UNDERLINE);
-		classStyle.addProperty(CssColorProperty.BACKGROUND, Color.BLUE);// override
+		classStyle.addProperty(CssColorProperty.BACKGROUND_COLOR, Color.BLUE);// override
 																		// tag
 																		// style
 
@@ -45,7 +45,7 @@ public class StyleMergerTest {
 																	// style
 
 		Style style = StyleMerger.mergeStyles(tagStyle, classStyle, inlineStyle);
-		Assert.assertEquals(style.getProperty(CssColorProperty.BACKGROUND), Color.BLUE);
+		Assert.assertEquals(style.getProperty(CssColorProperty.BACKGROUND_COLOR), Color.BLUE);
 		Assert.assertEquals(style.getProperty(CssStringProperty.FONT_WEIGHT), Style.BOLD_FONT_STYLE);
 		Assert.assertEquals(style.getProperty(CssIntegerProperty.BORDER_WIDTH), 4);
 		Assert.assertEquals(style.getProperty(CssStringProperty.FONT_STYLE), Style.TEXT_DECORATION_UNDERLINE);

--- a/src/test/java/uk/co/certait/htmlexporter/css/StyleParserTest.java
+++ b/src/test/java/uk/co/certait/htmlexporter/css/StyleParserTest.java
@@ -49,7 +49,8 @@ public class StyleParserTest {
 
 		assertThat(styleMap).containsKey("td");
 		style = styleMap.get("td");
-		assertThat(style.isBackgroundSet()).isFalse();
+		assertThat(style.isBackgroundSet()).isTrue();
+		assertThat(style.getProperty(CssColorProperty.BACKGROUND_COLOR)).isEqualTo(Color.decode("#999999"));
 		assertThat(style.getProperty(CssStringProperty.BORDER_STYLE)).isEqualTo(Style.SOLID_BORDER);
 		assertThat(style.getProperty(CssColorProperty.BORDER_TOP_COLOR)).isEqualTo(Color.decode("#656565"));
 		assertThat(style.getProperty(CssColorProperty.BORDER_BOTTOM_COLOR)).isEqualTo(Color.decode("#656565"));

--- a/src/test/java/uk/co/certait/htmlexporter/css/StyleParserTest.java
+++ b/src/test/java/uk/co/certait/htmlexporter/css/StyleParserTest.java
@@ -1,0 +1,83 @@
+package uk.co.certait.htmlexporter.css;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.awt.Color;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.Map;
+
+import org.apache.commons.io.IOUtils;
+import org.jsoup.nodes.Element;
+import org.jsoup.parser.Tag;
+import org.junit.Test;
+
+public class StyleParserTest {
+
+	private StyleParser parser = new StyleParser();
+
+	@Test
+	public void testParseStyles() throws IOException {
+		String stylesheet = IOUtils.resourceToString("/stylesheet_1.css", Charset.defaultCharset());
+
+		Element e = new Element(Tag.valueOf("style"), "") {
+			public String data() {
+				return stylesheet;
+			}
+		};
+
+		Map<String, Style> styleMap = parser.parseStyleSheet(e);
+
+		assertThat(styleMap).hasSize(6);
+
+		assertThat(styleMap).containsKey("th");
+		Style style = styleMap.get("th");
+		assertThat(style.getProperty(CssColorProperty.BACKGROUND_COLOR)).isEqualTo(Color.decode("#999999"));
+		assertThat(style.getProperty(CssColorProperty.BORDER_COLOR)).isEqualTo(Color.decode("#556677"));
+		assertThat(style.getProperty(CssIntegerProperty.BORDER_WIDTH)).isEqualTo(1);
+		assertThat(style.getProperty(CssColorProperty.COLOR)).isEqualTo(Color.decode("#ffffff"));
+		assertThat(style.getProperty(CssStringProperty.FONT_FAMILY)).isEqualTo("Georgia");
+		assertThat(style.getProperty(CssStringProperty.BORDER_TOP_STYLE)).isEqualTo(Style.DASHED_BORDER);
+		assertThat(style.getProperty(CssStringProperty.BORDER_BOTTOM_STYLE)).isEqualTo(Style.DASHED_BORDER);
+		assertThat(style.getProperty(CssStringProperty.BORDER_LEFT_STYLE)).isEqualTo(Style.DASHED_BORDER);
+		assertThat(style.getProperty(CssStringProperty.BORDER_RIGHT_STYLE)).isEqualTo(Style.DASHED_BORDER);
+		assertThat(style.isVerticallyAlignedMiddle()).isTrue();
+		assertThat(style.isFontBold()).isTrue();
+		assertThat(style.isFontItalic()).isTrue();
+		assertThat(style.isTextUnderlined()).isTrue();
+		assertThat(style.getProperty(CssIntegerProperty.FONT_SIZE)).isEqualTo(12);
+
+		assertThat(styleMap).containsKey("td");
+		style = styleMap.get("td");
+		assertThat(style.isBackgroundSet()).isFalse();
+		assertThat(style.getProperty(CssStringProperty.BORDER_STYLE)).isEqualTo(Style.SOLID_BORDER);
+		assertThat(style.getProperty(CssColorProperty.BORDER_TOP_COLOR)).isEqualTo(Color.decode("#656565"));
+		assertThat(style.getProperty(CssColorProperty.BORDER_BOTTOM_COLOR)).isEqualTo(Color.decode("#656565"));
+		assertThat(style.getProperty(CssColorProperty.BORDER_LEFT_COLOR)).isEqualTo(Color.decode("#656565"));
+		assertThat(style.getProperty(CssColorProperty.BORDER_RIGHT_COLOR)).isEqualTo(Color.decode("#656565"));
+		assertThat(style.getProperty(CssIntegerProperty.BORDER_WIDTH)).isEqualTo(1);
+		assertThat(style.getProperty(CssColorProperty.COLOR)).isEqualTo(Color.decode("#333333"));
+		assertThat(style.isVerticallyAlignedMiddle()).isTrue();
+		assertThat(style.isHorizontallyAlignedRight()).isTrue();
+		assertThat(style.isFontNameSet()).isFalse();
+		assertThat(style.isFontBold()).isFalse();
+		assertThat(style.isFontItalic()).isFalse();
+		assertThat(style.isTextUnderlined()).isFalse();
+		assertThat(style.getProperty(CssIntegerProperty.FONT_SIZE)).isEqualTo(10);
+
+		assertThat(styleMap).containsKey(".okay");
+		assertThat(styleMap).containsKey(".warning");
+		assertThat(styleMap).containsKey(".total");
+		assertThat(styleMap).containsKey(".fancy-border");
+
+		style = styleMap.get(".fancy-border");
+		assertThat(style.getProperty(CssColorProperty.BORDER_TOP_COLOR)).isEqualTo(Color.RED);
+		assertThat(style.getProperty(CssColorProperty.BORDER_RIGHT_COLOR)).isEqualTo(Color.GREEN);
+		assertThat(style.getProperty(CssColorProperty.BORDER_BOTTOM_COLOR)).isEqualTo(Color.ORANGE);
+		assertThat(style.getProperty(CssColorProperty.BORDER_LEFT_COLOR)).isEqualTo(Color.CYAN);
+		assertThat(style.getProperty(CssStringProperty.BORDER_TOP_STYLE)).isEqualTo(Style.DOTTED_BORDER);
+		assertThat(style.getProperty(CssStringProperty.BORDER_RIGHT_STYLE)).isEqualTo(Style.SOLID_BORDER);
+		assertThat(style.getProperty(CssStringProperty.BORDER_BOTTOM_STYLE)).isEqualTo(Style.DOUBLE_BORDER);
+		assertThat(style.getProperty(CssStringProperty.BORDER_LEFT_STYLE)).isEqualTo(Style.DASHED_BORDER);
+	}
+}

--- a/src/test/java/uk/co/certait/htmlexporter/css/StyleTest.java
+++ b/src/test/java/uk/co/certait/htmlexporter/css/StyleTest.java
@@ -50,11 +50,11 @@ public class StyleTest {
 		Assert.assertEquals(style1, style2);
 		Assert.assertEquals(style1.hashCode(), style2.hashCode());
 
-		style1.addProperty(CssColorProperty.BACKGROUND, Color.GREEN);
+		style1.addProperty(CssColorProperty.BACKGROUND_COLOR, Color.GREEN);
 		Assert.assertFalse(style1.equals(style2));
-		style2.addProperty(CssColorProperty.BACKGROUND, Color.RED);
+		style2.addProperty(CssColorProperty.BACKGROUND_COLOR, Color.RED);
 		Assert.assertFalse(style1.equals(style2));
-		style2.addProperty(CssColorProperty.BACKGROUND, Color.GREEN);
+		style2.addProperty(CssColorProperty.BACKGROUND_COLOR, Color.GREEN);
 		Assert.assertEquals(style1, style2);
 		Assert.assertEquals(style1.hashCode(), style2.hashCode());
 	}
@@ -154,7 +154,7 @@ public class StyleTest {
 		Style style = new Style();
 		Assert.assertFalse(style.isBackgroundSet());
 
-		style.addProperty(CssColorProperty.BACKGROUND, Color.RED);
+		style.addProperty(CssColorProperty.BACKGROUND_COLOR, Color.RED);
 
 		Assert.assertTrue(style.isBackgroundSet());
 	}

--- a/src/test/resources/stylesheet_1.css
+++ b/src/test/resources/stylesheet_1.css
@@ -1,0 +1,42 @@
+
+
+td, th{
+	background: #999999;
+	border: 1px solid #556677;
+	vertical-align: middle;
+}
+
+th{
+	color: #ffffff;
+	font: italic small-caps bold 12px Georgia;
+	text-decoration: underline;
+	text-align:center;
+	border-style: dashed;
+}
+
+td{
+	color: #333333;
+	border-color: #656565;
+	font-size: 10px;
+	text-align: right;
+}
+
+.okay {
+	background: #0f0f0f
+}
+
+.warning {
+	background: #ff0000
+}
+
+.total {
+	border-top-style: double;
+	border-bottom-style: dashed;
+	border-width: 2px;
+}
+
+.fancy-border {
+	border-color:red green orange cyan;
+	border-style: dotted solid double dashed;
+	border-width: 5px;
+}


### PR DESCRIPTION
- replaced the original CSS parser which is no longer maintained with a new CSS parser library
- added support for shorthand CSS properties via the new parser
- added support for a wider range of border formatting options 