### PR TITLE
bug fix for format applied to all fields with same style and format option for number fields

### DIFF
--- a/src/main/java/uk/co/certait/htmlexporter/writer/AbstractTableCellWriter.java
+++ b/src/main/java/uk/co/certait/htmlexporter/writer/AbstractTableCellWriter.java
@@ -141,11 +141,11 @@ public abstract class AbstractTableCellWriter implements TableCellWriter {
 		return element.attr(DATE_CELL_ATTRIBUTE);
 	}
 	
-	protected boolean isNumberCell(Element element) {
+	protected boolean isNumericCell(Element element) {
 		return getNumericValue(element) != null;
 	}
 	
-	protected String getNumberCellFormat(Element element) {
+	protected String getNumericCellFormat(Element element) {
 		return element.attr(NUMBER_CELL_ATTRIBUTE);
 	}
 

--- a/src/main/java/uk/co/certait/htmlexporter/writer/AbstractTableCellWriter.java
+++ b/src/main/java/uk/co/certait/htmlexporter/writer/AbstractTableCellWriter.java
@@ -140,6 +140,14 @@ public abstract class AbstractTableCellWriter implements TableCellWriter {
 	protected String getDateCellFormat(Element element) {
 		return element.attr(DATE_CELL_ATTRIBUTE);
 	}
+	
+	protected boolean isNumberCell(Element element) {
+		return getNumericValue(element) != null;
+	}
+	
+	protected String getNumberCellFormat(Element element) {
+		return element.attr(NUMBER_CELL_ATTRIBUTE);
+	}
 
 	/**
 	 * 

--- a/src/main/java/uk/co/certait/htmlexporter/writer/TableCellWriter.java
+++ b/src/main/java/uk/co/certait/htmlexporter/writer/TableCellWriter.java
@@ -22,6 +22,7 @@ public interface TableCellWriter {
 	public static final String DATA_GROUP_ATTRIBUTE = "data-group";
 	public static final String DATA_GROUP_OUTPUT_ATTRIBUTE = "data-group-output";
 	public static final String DATE_CELL_ATTRIBUTE = "data-date-cell-format";
+	public static final String NUMBER_CELL_ATTRIBUTE = "data-number-cell-format";
 	public static final String DATA_CELL_COMMENT_ATTRIBUTE = "data-cell-comment";
 	public static final String DATA_CELL_COMMENT_DIMENSION_ATTRIBUTE = "data-cell-comment-dimension";
 	public static final String DATA_TEXT_CELL = "data-text-cell";

--- a/src/main/java/uk/co/certait/htmlexporter/writer/excel/ExcelTableCellWriter.java
+++ b/src/main/java/uk/co/certait/htmlexporter/writer/excel/ExcelTableCellWriter.java
@@ -77,9 +77,9 @@ public class ExcelTableCellWriter extends AbstractTableCellWriter {
 			CellUtil.setCellStyleProperty(cell, CellUtil.DATA_FORMAT, dataFormat.getFormat(getDateCellFormat(element)));
 		}
 		
-		if (numericValue != null && getNumberCellFormat(element) != null) {
-			CellUtil.setCellStyleProperty(cell, CellUtil.DATA_FORMAT, dataFormat.getFormat(getNumberCellFormat(element)));
-			if (getNumberCellFormat(element).contains("%")) {
+		if (numericValue != null && getNumericCellFormat(element) != null) {
+			CellUtil.setCellStyleProperty(cell, CellUtil.DATA_FORMAT, dataFormat.getFormat(getNumericCellFormat(element)));
+			if (getNumericCellFormat(element).contains("%")) {
 				cell.setCellValue(numericValue / 100); // fix wrong excel interpretation of percent formatted values
 			}
 		}


### PR DESCRIPTION
The method getCellStyle.setFormat which was used to set the date format will change the format on all fields having the same style. Fixed by using CellUtil.setCellStyleProperty instead (see POI docs).

Added "data-number-cell-format" attribute in order to specify formatting of number fields.