### PR TITLE
Support external .css files via <link .../> elements in HTML <head> element + all enhancements from the fusionnx fork

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,13 @@ local.properties
 
 
 #################
+## IntelliJ
+#################
+
+/.idea
+
+
+#################
 ## Visual Studio
 #################
 
@@ -169,3 +176,5 @@ pip-log.txt
 /league.ods
 /league.xlsx
 /test.xlsx
+
+

--- a/pom.xml
+++ b/pom.xml
@@ -100,18 +100,6 @@
 			<version>0.7-incubating</version>
 		</dependency>
 
-		<!-- LOGGING -->
-		<dependency>
-			<groupId>ch.qos.logback</groupId>
-			<artifactId>logback-classic</artifactId>
-			<version>1.2.11</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-core</artifactId>
-			<version>2.17.2</version>
-		</dependency>
-
 
 		<!-- TEST ONLY -->
 		<dependency>
@@ -130,6 +118,20 @@
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
 			<version>3.22.0</version>
+			<scope>test</scope>
+		</dependency>
+
+		<!-- LOGGING -->
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<version>1.2.11</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
+			<version>2.17.2</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.github.alanhay</groupId>
 	<artifactId>html-exporter</artifactId>
-	<version>0.5.5</version>
+	<version>0.5.6-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<properties>

--- a/src/main/java/uk/co/certait/htmlexporter/css/CssStringProperty.java
+++ b/src/main/java/uk/co/certait/htmlexporter/css/CssStringProperty.java
@@ -21,7 +21,8 @@ public enum CssStringProperty {
 	BORDER_STYLE("border-style"), BORDER_TOP_STYLE("border-top-style"), BORDER_BOTTOM_STYLE("border-bottom-style"),
 	BORDER_LEFT_STYLE("border-left-style"), BORDER_RIGHT_STYLE("border-right-style"), BORDER_WIDTH("border-width"),
 	BORDER_TOP_WIDTH("border-top-width"), BORDER_BOTTOM_WIDTH("border-bottom-width"),
-	BORDER_LEFT_WIDTH("border-left-width"), BORDER_RIGHT_WIDTH("border-right-width");
+	BORDER_LEFT_WIDTH("border-left-width"), BORDER_RIGHT_WIDTH("border-right-width"),
+	WRAP_TEXT("wrap-text");
 
 	private String property;
 

--- a/src/main/java/uk/co/certait/htmlexporter/css/Style.java
+++ b/src/main/java/uk/co/certait/htmlexporter/css/Style.java
@@ -48,10 +48,22 @@ public class Style {
 	private Map<CssStringProperty, String> stringProperties;
 	private Map<CssColorProperty, Color> colorProperties;
 
+	private String datePattern;
+
 	public Style() {
 		integerProperties = new HashMap<CssIntegerProperty, Integer>();
 		stringProperties = new HashMap<CssStringProperty, String>();
 		colorProperties = new HashMap<CssColorProperty, Color>();
+	}
+
+	public boolean isEmpty() {
+		return integerProperties.isEmpty() && stringProperties.isEmpty() && colorProperties.isEmpty();
+	}
+
+	public void merge(Style style) {
+		getIntegerProperties().putAll(style.getIntegerProperties());
+		getStringProperties().putAll(style.getStringProperties());
+		getColorProperties().putAll(style.getColorProperties());
 	}
 
 	public void addProperty(CssIntegerProperty property, Integer value) {
@@ -84,6 +96,18 @@ public class Style {
 		return colorProperties;
 	}
 
+	public boolean hasProperty(CssIntegerProperty property) {
+		return integerProperties.get(property) != null;
+	}
+
+	public boolean hasProperty(CssStringProperty property) {
+		return stringProperties.get(property) != null;
+	}
+
+	public boolean hasProperty(CssColorProperty property) {
+		return colorProperties.get(property) != null;
+	}
+
 	public Optional<Integer> getProperty(CssIntegerProperty property) {
 		return Optional.ofNullable(integerProperties.get(property));
 	}
@@ -103,7 +127,7 @@ public class Style {
 	public boolean isWidthSet() {
 		return integerProperties.containsKey(CssIntegerProperty.WIDTH);
 	}
-	
+
 	public boolean isFontNameSet() {
 		return stringProperties.containsKey(CssStringProperty.FONT_FAMILY);
 	}
@@ -156,6 +180,18 @@ public class Style {
 		return colorProperties.containsKey(CssColorProperty.COLOR);
 	}
 
+	public boolean isWrapText() {
+		return "true".equals(stringProperties.get(CssStringProperty.WRAP_TEXT));
+	}
+
+	public void setDatePattern(String datePattern) {
+		this.datePattern = datePattern;
+	}
+
+	public String getDatePattern() {
+		return datePattern;
+	}
+
 	@Override
 	public boolean equals(Object obj) {
 		boolean equals = false;
@@ -166,7 +202,8 @@ public class Style {
 			Style other = (Style) obj;
 			equals = new EqualsBuilder().append(this.integerProperties, other.integerProperties)
 					.append(this.stringProperties, other.stringProperties)
-					.append(this.colorProperties, other.colorProperties).isEquals();
+					.append(this.colorProperties, other.colorProperties)
+					.append(this.datePattern, other.datePattern).isEquals();
 		}
 
 		return equals;
@@ -174,7 +211,7 @@ public class Style {
 
 	@Override
 	public int hashCode() {
-		return new HashCodeBuilder(17, 37).append(integerProperties).append(stringProperties).append(colorProperties)
+		return new HashCodeBuilder(17, 37).append(integerProperties).append(stringProperties).append(colorProperties).append(datePattern)
 				.toHashCode();
 	}
 }

--- a/src/main/java/uk/co/certait/htmlexporter/demo/ReportGeneratorExternalCss.java
+++ b/src/main/java/uk/co/certait/htmlexporter/demo/ReportGeneratorExternalCss.java
@@ -1,0 +1,170 @@
+/**
+ * Copyright (C) 2012 alanhay <alanhay99@hotmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.co.certait.htmlexporter.demo;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.RandomUtils;
+import org.apache.velocity.Template;
+import org.apache.velocity.VelocityContext;
+import org.apache.velocity.app.Velocity;
+import uk.co.certait.htmlexporter.demo.domain.*;
+import uk.co.certait.htmlexporter.pdf.PdfExporter;
+import uk.co.certait.htmlexporter.writer.IResourceLoader;
+import uk.co.certait.htmlexporter.writer.excel.ExcelExporter;
+import uk.co.certait.htmlexporter.writer.ods.OdsExporter;
+
+import java.io.*;
+import java.math.BigDecimal;
+import java.text.NumberFormat;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+import java.util.Properties;
+
+public class ReportGeneratorExternalCss
+{
+	public ReportGeneratorExternalCss() throws Exception {
+		File directory = new File(System.getProperty("user.home") + "/html-exporter");
+
+		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd-MM-yy-HH-mm-ss");
+		String timestamp = LocalDateTime.now().format(formatter);
+
+		if (!directory.exists()) {
+			directory.mkdirs();
+		}
+
+		LocalDateTime.now();
+
+		String html = generateHTML("report-external-css.vm");
+		saveFile(directory, "report-external-css" + timestamp + ".html", html.getBytes());
+
+		String relativeResourceBase = "src/main/resources";
+		String resourceBase = "/my/css/file/directory/styles";  // This could be something absolute like a repository of css files
+
+		ExcelExporter excelExporter = new ExcelExporter();
+
+		IResourceLoader resourceLoader = new IResourceLoader()
+		{
+			@Override
+			public String loadResourceContent(String uri)
+			{
+				String filename;
+				if (uri.startsWith("/"))
+					filename = resourceBase + File.separatorChar + uri;
+				else
+					filename = relativeResourceBase + File.separatorChar + uri;
+
+				try (FileReader fileReader = new FileReader(filename))
+				{
+					int bufSize = 1024;
+					char[] buf = new char[bufSize];
+					StringBuilder sb = new StringBuilder();
+					int offset = 0;
+
+
+					int charsRead = 0;
+					while (charsRead != -1)
+					{
+						charsRead = fileReader.read(buf, offset, bufSize);
+						if (charsRead != -1)
+							sb.append(buf, 0, charsRead);
+					}
+					return sb.toString();
+				}
+				catch (IOException ioe)
+				{
+					throw new RuntimeException("loadResourceContent failed: " + ioe);
+				}
+			}
+		};
+
+		excelExporter.setResourceLoader(resourceLoader);
+
+		excelExporter.exportHtml(html, new File(directory, "report-external-css" + timestamp + ".xlsx"));
+
+//		new PdfExporter().exportHtml(html, new File(directory, "report-" + timestamp + ".pdf"));
+//		new OdsExporter().exportHtml(html, new File(directory, "report-" + timestamp + ".ods"));
+	}
+
+	public static void main(String[] args) throws Exception {
+		new ReportGeneratorExternalCss();
+
+		System.exit(0);
+	}
+
+	public String generateHTML(String templateName) {
+		Properties props = new Properties();
+		props.put("resource.loader", "class");
+		props.put("class.resource.loader.class", "org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader");
+
+		Velocity.init(props);
+		Template template = Velocity.getTemplate(templateName);
+
+		VelocityContext context = new VelocityContext();
+		context.put("numberFormatter", NumberFormat.getInstance(Locale.UK));
+		context.put("data", generateData());
+		context.put("productGroups", ProductGroup.values());
+		Writer writer = new StringWriter();
+		template.merge(context, writer);
+
+		return writer.toString();
+	}
+
+	public SalesReportData generateData() {
+		SalesReportData data = new SalesReportData();
+
+		String[] areaNames = { "North", "South", "East", "West" };
+		String[][] regionNames = { { "Grampian", "Highland" }, { "Borders", "Dumfries" },
+				{ "Fife", "Lothian", "Tayside" }, { "Argyll", "Ayrshire", "Glasgow" } };
+
+		for (int i = 0; i < areaNames.length; ++i) {
+			Area area = new Area(i, areaNames[i]);
+
+			int storeCount = RandomUtils.nextInt(1, 2) + 2;
+
+			for (int j = 0; j < regionNames[i].length; ++j) {
+				Region region = new Region(i + "_" + j, regionNames[i][j]);
+				area.addRegion(region);
+
+				for (int k = 0; k < storeCount; ++k) {
+					Store store = new Store(region.getName() + "_" + (k + 1), region.getName() + " Store " + (k + 1));
+					region.addStore(store);
+
+					for (ProductGroup group : ProductGroup.values()) {
+						int saleCount = RandomUtils.nextInt(1, 50);
+
+						for (int m = 0; m < saleCount; ++m) {
+							int value = RandomUtils.nextInt(1, 100) + 10;
+							store.addSale(new Sale(group, new BigDecimal(Integer.toString(value))));
+						}
+					}
+				}
+			}
+
+			data.addArea(area);
+		}
+
+		return data;
+	}
+
+	public void saveFile(File directory, String fileName, byte[] data) throws IOException {
+		File file = new File(directory, fileName);
+		FileOutputStream out = new FileOutputStream(file);
+		IOUtils.write(data, out);
+		out.flush();
+		out.close();
+	}
+}

--- a/src/main/java/uk/co/certait/htmlexporter/pdf/PdfExporter.java
+++ b/src/main/java/uk/co/certait/htmlexporter/pdf/PdfExporter.java
@@ -20,6 +20,9 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -28,6 +31,18 @@ import org.w3c.dom.Document;
 import org.xhtmlrenderer.pdf.ITextRenderer;
 
 public class PdfExporter {
+
+	protected List<String> fontPaths;
+
+	public void registerFontPath(String path) {
+		getFontPaths().add(path);
+	}
+
+	public List<String> getFontPaths() {
+		if(fontPaths == null) fontPaths = new ArrayList<>();
+		return fontPaths;
+	}
+
 	public byte[] exportHtml(String html) throws Exception {
 		ByteArrayOutputStream out = new ByteArrayOutputStream();
 		exportHtml(html, out);
@@ -41,14 +56,14 @@ public class PdfExporter {
 
 	private void exportHtml(String html, OutputStream out) throws Exception {
 		DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
-		Document doc = builder.parse(new ByteArrayInputStream(html.replaceAll("&nbsp;", "").getBytes()));
+		Document doc = builder.parse(new ByteArrayInputStream(html.replaceAll("&nbsp;", "").getBytes(StandardCharsets.UTF_8)));
 
 		ITextRenderer renderer = new ITextRenderer();
 		renderer.setDocument(doc, null);
 
-		// FIXME
-		// renderer.getFontResolver().addFont("C:/Windows/Fonts/CALIBRI.TTF",
-		// true);
+		for(String path : getFontPaths()) {
+			renderer.getFontResolver().addFont(path, true);
+		}
 
 		renderer.layout();
 		renderer.createPDF(out);

--- a/src/main/java/uk/co/certait/htmlexporter/writer/AbstractExporter.java
+++ b/src/main/java/uk/co/certait/htmlexporter/writer/AbstractExporter.java
@@ -31,12 +31,24 @@ import uk.co.certait.htmlexporter.css.StyleMap;
 import uk.co.certait.htmlexporter.css.StyleParser;
 
 public abstract class AbstractExporter implements Exporter {
+	protected String datePattern = "yyyy-MM-dd";
 
 	private static final String DATA_NEW_SHEET_ATTRIBUTE = "data-new-sheet";
 	private static final String DATA_SHEET_NAME_ATTRIBUTE = "data-sheet-name";
 
 	// Optional resource loader to load external CSS files
 	protected IResourceLoader resourceLoader;
+
+	protected Document document;
+
+	protected Document parse(String html) {
+		document = Jsoup.parse(html);
+		return document;
+	}
+
+	protected Document getDocument() {
+		return document;
+	}
 
 	public byte[] exportHtml(String html) throws IOException {
 		ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -50,16 +62,22 @@ public abstract class AbstractExporter implements Exporter {
 		exportHtml(html, out);
 	}
 
-	protected Elements getTables(String html) {
-		Document document = Jsoup.parse(html);// FIXME parsing twice
+	public void setDatePattern(String datePattern) {
+		this.datePattern = datePattern;
+	}
 
+	public String getDatePattern() {
+		return this.datePattern;
+	}
+
+	protected Elements getTables() {
+		Document document = getDocument();
 		return document.getElementsByTag("table");
 	}
 
-	protected StyleMap getStyleMapper(String html) {
-		Document document = Jsoup.parse(html);
-		Elements styles = document.getElementsByTag("style");// FIXME parsing
-																// twice
+	protected StyleMap getStyleMapper() {
+		Document document = getDocument();
+		Elements styles = document.getElementsByTag("style");
 
 		// Load any external .css files specified in the <head> section as <link .. > tags
 		// and add the classes to the styles collection

--- a/src/main/java/uk/co/certait/htmlexporter/writer/AbstractExporter.java
+++ b/src/main/java/uk/co/certait/htmlexporter/writer/AbstractExporter.java
@@ -22,6 +22,7 @@ import java.io.OutputStream;
 
 import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.jsoup.Jsoup;
+import org.jsoup.nodes.DataNode;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
@@ -33,6 +34,9 @@ public abstract class AbstractExporter implements Exporter {
 
 	private static final String DATA_NEW_SHEET_ATTRIBUTE = "data-new-sheet";
 	private static final String DATA_SHEET_NAME_ATTRIBUTE = "data-sheet-name";
+
+	// Optional resource loader to load external CSS files
+	protected IResourceLoader resourceLoader;
 
 	public byte[] exportHtml(String html) throws IOException {
 		ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -57,6 +61,37 @@ public abstract class AbstractExporter implements Exporter {
 		Elements styles = document.getElementsByTag("style");// FIXME parsing
 																// twice
 
+		// Load any external .css files specified in the <head> section as <link .. > tags
+		// and add the classes to the styles collection
+		// NOTE: we ignore any external CSS links not defined in the <head> section.
+		// This will add the styles from any external .css files as children of the styles collection.
+		Elements headElements = document.getElementsByTag("head");
+
+		// The linked stylesheets are in the head and are assumed to fall prior to any inline style elements
+		// so they are inserted at the start in the order they appear in
+		int index = 0;
+
+		for(Element head: headElements)
+		{
+			for (Element link : head.getElementsByTag("link"))
+			{
+				String rel = link.attr("rel");
+				if (rel != null && rel.equals("stylesheet"))
+				{
+					if (resourceLoader == null)
+						throw new RuntimeException("Attempt to load contents of external .css file but no resource loader configured");
+
+					Element styleElement = new Element("style");
+
+					String uri = link.attr("href");
+					String cssContent = resourceLoader.loadResourceContent(uri);
+					DataNode styleContent = new DataNode(cssContent);
+					styleElement.appendChild(styleContent);
+					styles.add(index++, styleElement);
+				}
+			}
+		}
+
 		StyleParser parser = new StyleParser();
 		StyleMap mapper = new StyleMap(parser.parseStyleSheets(styles));
 
@@ -72,4 +107,8 @@ public abstract class AbstractExporter implements Exporter {
 	}
 
 	public abstract void exportHtml(String html, OutputStream out) throws IOException;
+
+	public void setResourceLoader(IResourceLoader iResourceLoader) {
+		resourceLoader = iResourceLoader;
+	}
 }

--- a/src/main/java/uk/co/certait/htmlexporter/writer/AbstractTableRowWriter.java
+++ b/src/main/java/uk/co/certait/htmlexporter/writer/AbstractTableRowWriter.java
@@ -26,6 +26,10 @@ public abstract class AbstractTableRowWriter implements TableRowWriter {
 		rowTracker = new RowTracker();
 	}
 
+	protected TableCellWriter getCellWriter() {
+		return cellWriter;
+	}
+
 	public void writeRow(Element row, int rowIndex) {
 		renderRow(row, rowIndex);
 

--- a/src/main/java/uk/co/certait/htmlexporter/writer/IResourceLoader.java
+++ b/src/main/java/uk/co/certait/htmlexporter/writer/IResourceLoader.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (C) 2012 alanhay <alanhay99@hotmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.co.certait.htmlexporter.writer;
+
+public interface IResourceLoader {
+	
+	public String loadResourceContent(String uri);
+}

--- a/src/main/java/uk/co/certait/htmlexporter/writer/excel/ExcelStyleGenerator.java
+++ b/src/main/java/uk/co/certait/htmlexporter/writer/excel/ExcelStyleGenerator.java
@@ -50,6 +50,11 @@ public class ExcelStyleGenerator {
 
 	static {
 		BORDER_STYLE_MAP.put(new BorderMappingKey("solid", null), BorderStyle.THIN);
+		BORDER_STYLE_MAP.put(new BorderMappingKey("solid", "1px"), BorderStyle.THIN);
+		BORDER_STYLE_MAP.put(new BorderMappingKey("solid", "2px"), BorderStyle.MEDIUM);
+		BORDER_STYLE_MAP.put(new BorderMappingKey("solid", "3px"), BorderStyle.MEDIUM);
+		BORDER_STYLE_MAP.put(new BorderMappingKey("solid", "4px"), BorderStyle.THICK);
+		BORDER_STYLE_MAP.put(new BorderMappingKey("solid", "5px"), BorderStyle.THICK);
 		BORDER_STYLE_MAP.put(new BorderMappingKey("solid", "thin"), BorderStyle.THIN);
 		BORDER_STYLE_MAP.put(new BorderMappingKey("solid", "medium"), BorderStyle.MEDIUM);
 		BORDER_STYLE_MAP.put(new BorderMappingKey("solid", "thick"), BorderStyle.THICK);
@@ -97,6 +102,8 @@ public class ExcelStyleGenerator {
 			dataFormat = createHelper.createDataFormat().getFormat(element.attr(DATE_CELL_ATTRIBUTE));
 		} else if (element.hasAttr(DATA_NUMERIC_CELL_FORMAT_ATTRIBUTE)) {
 			dataFormat = createHelper.createDataFormat().getFormat(element.attr(DATA_NUMERIC_CELL_FORMAT_ATTRIBUTE));
+		} else if(style.getDatePattern() != null && !style.getDatePattern().trim().isEmpty()) {
+			dataFormat = createHelper.createDataFormat().getFormat(style.getDatePattern());
 		}
 
 		StyleCacheKey styleCacheKey = new StyleCacheKey(style, dataFormat);
@@ -110,7 +117,8 @@ public class ExcelStyleGenerator {
 			applyBorders(style, cellStyle);
 			applyFont(cell, style, cellStyle);
 			applyHorizontalAlignment(style, cellStyle);
-			applyverticalAlignment(style, cellStyle);
+			applyVerticalAlignment(style, cellStyle);
+			applyParagraph(style, cellStyle);
 			applyWidth(cell, style);
 
 			if (dataFormat > -1) {
@@ -210,13 +218,19 @@ public class ExcelStyleGenerator {
 		}
 	}
 
-	protected void applyverticalAlignment(Style style, XSSFCellStyle cellStyle) {
+	protected void applyVerticalAlignment(Style style, XSSFCellStyle cellStyle) {
 		if (style.isVerticallyAlignedTop()) {
 			cellStyle.setVerticalAlignment(VerticalAlignment.TOP);
 		} else if (style.isVerticallyAlignedBottom()) {
 			cellStyle.setVerticalAlignment(VerticalAlignment.BOTTOM);
 		} else if (style.isVerticallyAlignedMiddle()) {
 			cellStyle.setVerticalAlignment(VerticalAlignment.CENTER);
+		}
+	}
+
+	protected void applyParagraph(Style style, XSSFCellStyle cellStyle) {
+		if (style.isWrapText()) {
+			cellStyle.setWrapText(true);
 		}
 	}
 

--- a/src/main/java/uk/co/certait/htmlexporter/writer/excel/ExcelTableCellWriter.java
+++ b/src/main/java/uk/co/certait/htmlexporter/writer/excel/ExcelTableCellWriter.java
@@ -18,6 +18,7 @@ package uk.co.certait.htmlexporter.writer.excel;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.Date;
 
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellType;
@@ -26,8 +27,7 @@ import org.jsoup.nodes.Element;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import uk.co.certait.htmlexporter.css.Style;
-import uk.co.certait.htmlexporter.css.StyleMap;
+import uk.co.certait.htmlexporter.css.*;
 import uk.co.certait.htmlexporter.ss.CellRange;
 import uk.co.certait.htmlexporter.ss.Function;
 import uk.co.certait.htmlexporter.writer.AbstractTableCellWriter;
@@ -39,6 +39,7 @@ public class ExcelTableCellWriter extends AbstractTableCellWriter {
 	private Sheet sheet;
 	private StyleMap styleMapper;
 	private ExcelStyleGenerator styleGenerator;
+	private ExcelStyleGenerator rowStyleGenerator;
 
 	public ExcelTableCellWriter(Sheet sheet, StyleMap styleMapper) {
 		this.sheet = sheet;
@@ -47,21 +48,40 @@ public class ExcelTableCellWriter extends AbstractTableCellWriter {
 		styleGenerator = new ExcelStyleGenerator();
 	}
 
+	public void setRowStyleGenerator(ExcelStyleGenerator rowStyleGenerator) {
+		this.rowStyleGenerator = rowStyleGenerator;
+	}
+
+	public ExcelStyleGenerator getRowStyleGenerator() {
+		return rowStyleGenerator;
+	}
+
 	@Override
 	public void renderCell(Element element, int rowIndex, int columnIndex) {
 		Cell cell = sheet.getRow(rowIndex).createCell(columnIndex);
 
 		Double numericValue;
+		Date dateValue = null;
 
+		String datePattern = null;
+		boolean wrapText = false;
 		if (isDateCell(element)) {
+			String dateCellFormat = getDateCellFormat(element);
 			DateFormat df = new SimpleDateFormat(getDateCellFormat(element));
 
 			try {
-				cell.setCellValue(df.parse(getElementText(element)));
-			} catch (ParseException pex) {
-				logger.error("Error processing date cell with format specified as {} and value {}",
-						getDateCellFormat(element), getElementText(element), pex);
+				dateValue = df.parse(getElementText(element));
+				cell.setCellValue(dateValue);
+				datePattern = dateCellFormat;
+			} catch(ParseException pex) {
+				logger.error("Error processing date cell with format specified as {} and value {}", getDateCellFormat(element), getElementText(element), pex);
 			}
+		} else if(isPossibleDateCell(element) && (dateValue = getDateValue(element, getDatePattern())) != null) {
+			cell.setCellValue(dateValue);
+			datePattern = getDatePattern();
+		} else if(isPossibleDateTimeCell(element) && (dateValue = getDateTimeValue(element, getDateTimePattern())) != null) {
+			cell.setCellValue(dateValue);
+			datePattern = toExcelDateTimePattern(getDateTimePattern());
 		} else if ((numericValue = getNumericValue(element)) != null) {
 			if (isPercentageCell(element)) {
 				cell.setCellValue(numericValue / 100);
@@ -70,11 +90,21 @@ public class ExcelTableCellWriter extends AbstractTableCellWriter {
 			}
 		} else {
 			cell = sheet.getRow(rowIndex).createCell(columnIndex, CellType.STRING);
-			cell.setCellValue(getElementText(element));
+
+			String text = getElementText(element);
+			cell.setCellValue(text);
+
+			wrapText = (text.contains("\n") || text.length() > ExcelExporter.MAX_COLUMN_WIDTH);
 		}
 
-		Style style = styleMapper.getStyleForElement(element);
-		cell.setCellStyle(styleGenerator.getStyle(element, cell, style));
+		Style cellStyle = dateValue != null ? styleMapper.getDateStyleForElement(element, datePattern) :
+						  styleMapper.getStyleForElement(element);
+
+		if(wrapText) {
+			cellStyle.addProperty(CssStringProperty.WRAP_TEXT, "true");
+		}
+
+		cell.setCellStyle(styleGenerator.getStyle(element, cell, cellStyle));
 
 		String commentText;
 
@@ -92,4 +122,18 @@ public class ExcelTableCellWriter extends AbstractTableCellWriter {
 
 		new ExcelFunctionCell(cell, range, new ExcelCellRangeResolver(), function);
 	}
+
+	/**
+	 * Converts a date pattern (e.g. from Java) to one that can be used by Excel.
+	 *
+	 * @param dateTimePattern
+	 * @return
+	 */
+	private String toExcelDateTimePattern(String dateTimePattern) {
+		if(dateTimePattern.matches("^.*a$")) { // 1. Replace 'a' at the end of the pattern with AM/PM
+			return dateTimePattern.substring(0, dateTimePattern.lastIndexOf("a")) + "AM/PM";
+		}
+		return dateTimePattern;
+	}
+
 }

--- a/src/main/java/uk/co/certait/htmlexporter/writer/excel/ExcelTableRowWriter.java
+++ b/src/main/java/uk/co/certait/htmlexporter/writer/excel/ExcelTableRowWriter.java
@@ -15,11 +15,14 @@
  */
 package uk.co.certait.htmlexporter.writer.excel;
 
+import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.util.CellRangeAddress;
 import org.apache.poi.xssf.usermodel.XSSFCell;
 import org.jsoup.nodes.Element;
 
+import uk.co.certait.htmlexporter.css.Style;
+import uk.co.certait.htmlexporter.css.StyleMap;
 import uk.co.certait.htmlexporter.writer.AbstractTableRowWriter;
 import uk.co.certait.htmlexporter.writer.TableCellWriter;
 

--- a/src/main/java/uk/co/certait/htmlexporter/writer/ods/OdsExporter.java
+++ b/src/main/java/uk/co/certait/htmlexporter/writer/ods/OdsExporter.java
@@ -36,12 +36,14 @@ public class OdsExporter extends AbstractExporter {
 		try {
 			spreadsheet = SpreadsheetDocument.newSpreadsheetDocument();
 			Table table = spreadsheet.getSheetByIndex(0);
-			;
-			StyleMap styleMapper = getStyleMapper(html);
+
+			parse(html);
+
+			StyleMap styleMapper = getStyleMapper();
 			int startRow = 0;
 			boolean firstLoop = true;
 
-			for (Element element : getTables(html)) {
+			for (Element element : getTables()) {
 
 				if (firstLoop) {
 					String sheetName = getSheetName(element);

--- a/src/main/resources/report-external-css.vm
+++ b/src/main/resources/report-external-css.vm
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<link rel="stylesheet" type="text/css" href="./report.css" />
+	</head>
+	<body>
+		<table style="width:100%;">
+			#set($columnCount = $productGroups.size() * 2 + 5)
+				<tr>
+					<th class="reportHeader" colspan="$columnCount">Daily Sales Report: 21-Jun-2012</th>
+				</tr>
+		</table>
+		<br/>
+		#set($areas = $data.areas)
+		#set($numberFormat = "#[[#,##0]]#")
+		<table style="width:100%;">
+			<tr>
+				<th style="width:120px;">Area</th>
+				<th style="width:120px;">Region</th>
+				<th style="width:120px;">Store</th>
+				
+				#foreach($group in $productGroups)
+					<th colspan="2" style="text-align:center;">$group</th>
+				#end
+                
+				<th colspan="2" style="text-align:center;">Total Sales</th>
+			</tr>
+			<tr>
+				<th>&nbsp;</th>
+				<th>&nbsp;</th>
+				<th>&nbsp;</th>
+				
+				#foreach($group in $productGroups) 
+					<th style="text-align:center;">Count </th>
+					<th style="text-align:center;">Value</th>
+				#end
+				
+				<th style="text-align:center;">Count</th>
+				<th style="text-align:center;">Value</th>
+			</tr>
+			<!-- LOOP AREAS -->
+			#foreach($area in $areas)
+				#set($firstAreaLoop = true)
+				
+				<!-- FOR EACH REGION -->
+				#foreach($region in $area.regions)
+					#set($firstRegionLoop = true)
+    				#set($dataRowCount = 0)
+					
+    				<!-- FOR EACH STORE -->
+    				#foreach($store in $region.stores)
+    					#if($dataRowCount % 2 ==0)
+    						#set($backgroundClass="oddRow")
+    					#else
+    						#set($backgroundClass="")
+    					#end	
+    					<tr>
+    						#if($firstAreaLoop)
+    							#set($areaRowSpan = $area.numberOfRegions + $area.numberOfStores)
+    							<td class="areaClass" rowspan="$areaRowSpan">$area.name</td>
+    							#set($firstAreaLoop = false)
+    						#end
+    						#if($firstRegionLoop)
+    							#set($regionRowSpan = $region.numberOfStores)
+    							<td class="regionClass" rowspan="$regionRowSpan">$region.name</td>
+    							#set($firstRegionLoop = false)
+    						#end
+    						<td class="$backgroundClass">$store.name</td>
+    						
+							<!-- FOR EACH PRODUCT GROUP-->
+            				#foreach($group in $productGroups)	
+            						<td data-group="store_${store.id}_count, region_${region.id}_pg_${group.id}_count" 
+											class="numeric $backgroundClass">
+    									$store.getNumberOfSalesForProductGroup($group)
+                                    </td>
+    								#if($store == $area.getBestPerformingStoreForProductGroup($group))
+    									#set($bestPerformingClass = "bestPerforming")
+    								#else
+    									#set($bestPerformingClass = "")
+									#end
+									
+									#if($store.getValueOfSalesForProductGroup($group) < 200)
+										#set($cellComment = "data-cell-comment='Random Comment: Sales &lt; 200'")
+										#set($cellCommentDimension = "data-cell-comment-dimension='4,1'")
+									#else
+										#set($cellComment = "")
+										#set($cellCommentDimension = "")
+									#end
+            						<td data-group="store_${store.id}_value, region_${region.id}_pg_${group.id}_value" $cellComment $cellCommentDimension
+											class="numeric $backgroundClass $bestPerformingClass" data-numeric-cell-format="$numberFormat">
+            							$numberFormatter.format($store.getValueOfSalesForProductGroup($group))
+                                    </td>                            
+    						#end
+    						
+    						<!-- TOTAL FOR STORES -->
+    						<td data-group-output="store_${store.id}_count" data-group="region_${region.id}_count" 
+									class="numeric $backgroundClass">
+    							$store.numberOfSales
+                            </td>
+    						<td data-group-output="store_${store.id}_value" data-group="region_${region.id}_value" 
+									class="numeric $backgroundClass" data-numeric-cell-format="$numberFormat">
+    							$numberFormatter.format($store.valueOfSales)
+                            </td>   
+    						
+    						#set($dataRowCount = $dataRowCount + 1)
+    					</tr>
+    				#end <!--END STORES LOOP-->
+				
+					<!--OUTPUT TOTALS FOR REGION-->
+					<tr class="subTotal">
+    					<td>$region.name Sub-total</td>
+						<td>&nbsp;</td>
+						
+    					#foreach($group in $productGroups) 
+        					<td class="numeric" data-group-output="region_${region.id}_pg_${group.id}_count" 
+									data-group="area_${area.id}_pg_${group.id}_count">
+        						$region.getNumberOfSalesForProductGroup($group)
+                            </td>
+        					<td class="numeric" data-group-output="region_${region.id}_pg_${group.id}_value" 
+									data-group="area_${area.id}_pg_${group.id}_value" data-numeric-cell-format="$numberFormat">
+        						$numberFormatter.format($region.getValueOfSalesForProductGroup($group))
+        					</td>
+    					#end
+    					
+    					<!-- TOTAL FOR REGION -->
+    					<td class="numeric" data-group-output="region_${region.id}_count" 
+								data-group="area_${area.id}_count">
+    						$region.numberOfSales
+                        </td>
+    					<td class="numeric" data-group-output="region_${region.id}_value" 
+								data-group="area_${area.id}_value" data-numeric-cell-format="$numberFormat">
+    						$numberFormatter.format($region.valueOfSales)
+                        </td>   
+    				</tr>
+					
+				#end <!--END REGIONS LOOPS-->
+				
+				<!-- OUPUT TOTALS FOR AREA-->
+				<tr class="areaSubTotal">
+					<td>$area.name Sub-total</td>
+                    <td>&nbsp;</td>
+					<td>&nbsp;</td>
+					
+					#foreach($group in $productGroups) 
+    					<td class="numeric" data-group-output="area_${area.id}_pg_${group.id}_count" 
+								data-group="pg_${group.id}_count">
+    						$area.getNumberOfSalesForProductGroup($group)
+                        </td>
+    					<td class="numeric" data-group-output="area_${area.id}_pg_${group.id}_value" 
+								data-group="pg_${group.id}_value" data-numeric-cell-format="$numberFormat">
+    						$numberFormatter.format($area.getValueOfSalesForProductGroup($group))
+    					</td>
+					#end
+					
+					<!-- TOTAL FOR AREA -->
+					<td class="numeric" data-group-output="area_${area.id}_count" 
+							data-group="total_count">
+						$area.numberOfSales
+                    </td>
+					<td class="numeric" data-group-output="area_${area.id}_value" 
+							data-group="total_value" data-numeric-cell-format="$numberFormat">
+						$numberFormatter.format($area.valueOfSales)
+                    </td>   
+				</tr>
+			#end	<!-- END AREA LOOP -->
+			
+			<!-- OUTPUT GRAND TOTALS-->
+			<tr class="total">
+                <td>Grand Totals</td>
+                <td>&nbsp;</td>
+				<td>&nbsp;</td>
+				
+    			#foreach($group in $productGroups) 
+    				<td class="numeric" data-group-output="pg_${group.id}_count">
+    					$data.getNumberOfSalesForProductGroup($group)
+                    </td>
+    				<td class="numeric" data-group-output="pg_${group.id}_value" data-numeric-cell-format="$numberFormat">
+    					$numberFormatter.format($data.getValueOfSalesForProductGroup($group))
+    				</td>
+				#end
+				
+                <td class="numeric" data-group-output="total_count">$data.numberOfSales</td>
+                <td class="numeric" data-group-output="total_value" data-numeric-cell-format="$numberFormat">$numberFormatter.format($data.valueOfSales)</td>
+			</tr>
+		</table>
+		<br/>
+		<table>
+			<tr>
+				<td class="bestPerforming">&nbsp;&nbsp;</td>
+				<td colspan="5" style="border-width:0px;">Best Performing Store in Area for Product Group</td>
+			</tr>
+		</table>
+	</body>
+</html>

--- a/src/main/resources/report-multi-sheet.vm
+++ b/src/main/resources/report-multi-sheet.vm
@@ -1,7 +1,10 @@
 <!DOCTYPE html>
 <html>
     <head>
-        #include("./report.css")
+	    <!-- Declare style element outside of report.css so that its content can be valid CSS -->
+	    <style>
+            #include("./report.css")
+        </style
     </head>
     <body>
         #set($areas = $data.areas)

--- a/src/main/resources/report.css
+++ b/src/main/resources/report.css
@@ -1,67 +1,68 @@
-<style>
-	@page {
-	    size: landscape;
-	    margin: 2%;
-	}
-	
-	table {
-		border-collapse: collapse;
-		border-spacing: 0;
-	}
-	
-	th, td{
-		font-family: "Courier New";
-		border: thin solid #444444;
-		padding-left: 2px;
-		padding-right: 2px;
-	}
-	
-	th{
-		background: #336699;
-		color: #eeeeee;
-		font-weight: bold;
-		font-size: 10px;
-		text-align:left;
-	}
-	
-	td{
-		font-size:10px;
-	}
-	
-	.reportHeader{
-		font-size:16px;
-		background: #336699;
-		color: #eeeeee;
-		text-align:left;
-	}
-	
-	.areaClass, .regionClass{
-		vertical-align:middle;
-	}
-	
-	.subTotal{
-		background: #FFCC33;
-	}
-	
-	.areaSubTotal{
-		background: #FF9900;
-	}
-	
-	.total{
-		background: #336699;
-		color: #eeeeee;
-	}
-	
-	.numeric{
-		text-align:right;
-	}
-	
-	.oddRow{
-		background: #FFFFCC;
-	}
-	
-	.bestPerforming{
-		background: #aa0000;
-		color: #dddddd;
-	}
-</style>
+/*
+We do not include any wrapping <style> tag here so that this file can remain valid CSS
+*/
+@page {
+    size: landscape;
+    margin: 2%;
+}
+
+table {
+    border-collapse: collapse;
+    border-spacing: 0;
+}
+
+th, td{
+    font-family: "Courier New";
+    border: thin solid #444444;
+    padding-left: 2px;
+    padding-right: 2px;
+}
+
+th{
+    background: #336699;
+    color: #eeeeee;
+    font-weight: bold;
+    font-size: 10px;
+    text-align:left;
+}
+
+td{
+    font-size:10px;
+}
+
+.reportHeader{
+    font-size:16px;
+    background: #336699;
+    color: #eeeeee;
+    text-align:left;
+}
+
+.areaClass, .regionClass{
+    vertical-align:middle;
+}
+
+.subTotal{
+    background: #FFCC33;
+}
+
+.areaSubTotal{
+    background: #FF9900;
+}
+
+.total{
+    background: #336699;
+    color: #eeeeee;
+}
+
+.numeric{
+    text-align:right;
+}
+
+.oddRow{
+    background: #FFFFCC;
+}
+
+.bestPerforming{
+    background: #aa0000;
+    color: #dddddd;
+}

--- a/src/main/resources/report.vm
+++ b/src/main/resources/report.vm
@@ -1,7 +1,10 @@
 <!DOCTYPE html>
 <html>
 	<head>
-		#include("./report.css")
+	    <!-- Declare style element outside of report.css so that its content can be valid CSS -->
+	    <style>
+		    #include("./report.css")
+		</style>
 	</head>
 	<body>
 		<table style="width:100%;">

--- a/src/test/java/uk/co/certait/htmlexporter/css/StyleParserTest.java
+++ b/src/test/java/uk/co/certait/htmlexporter/css/StyleParserTest.java
@@ -46,7 +46,7 @@ public class StyleParserTest {
 		assertThat(style.isFontBold()).isTrue();
 		assertThat(style.isFontItalic()).isTrue();
 		assertThat(style.isTextUnderlined()).isTrue();
-		assertThat(style.getProperty(CssIntegerProperty.FONT_SIZE).get()).isEqualTo(12);
+		assertThat(style.getProperty(CssIntegerProperty.FONT_SIZE).get()).isEqualTo(9);
 
 		assertThat(styleMap).containsKey("td");
 		style = styleMap.get("td");
@@ -65,7 +65,7 @@ public class StyleParserTest {
 		assertThat(style.isFontBold()).isFalse();
 		assertThat(style.isFontItalic()).isFalse();
 		assertThat(style.isTextUnderlined()).isFalse();
-		assertThat(style.getProperty(CssIntegerProperty.FONT_SIZE).get()).isEqualTo(10);
+		assertThat(style.getProperty(CssIntegerProperty.FONT_SIZE).get()).isEqualTo(7);
 
 		assertThat(styleMap).containsKey(".okay");
 		assertThat(styleMap).containsKey(".warning");
@@ -111,7 +111,7 @@ public class StyleParserTest {
 		assertThat(style.getProperty(CssColorProperty.BACKGROUND_COLOR).get()).isEqualTo(Color.decode("#ff0000"));
 
 		// Specified only in 2nd <style/>
-		assertThat(style.getProperty(CssIntegerProperty.FONT_SIZE).get()).isEqualTo(20);
+		assertThat(style.getProperty(CssIntegerProperty.FONT_SIZE).get()).isEqualTo(15);
 
 		// Property in 1st <Style/> overwritten in 2nd <style/>
 		assertThat(style.getProperty(CssColorProperty.COLOR).get()).isEqualTo(Color.ORANGE);


### PR DESCRIPTION
Some HTML is produced by tools which do not 'auto embed' the contents of #include files into the generated source but assume that the HTML processor will be able to include .css files added via <link .. /> elements in the header at processing time.
Previously html-exporter was not such a HTML processor but with this enhancement, by setting an IResourceLoader, html-exporter is capable of handling external .css files specified in <link ../> elements within the <head> element.

The demo report.vm includes a file called report.css - this was not a "well formed" .css file because its contents were wrapped within:
```
<style>
...
</style>

```

**Note:** With support for external css files the report.css file needed to be a "well formed" .css file so the <style..> wrapper has been removed from the .css file and placed within the report.vm file. This means that the new demo file report-external-css.vm can share this report.css file.

The inclusion of external .css files is facilitated with an implementation of IResourceLoader that must be supplied by the user of the html-exporter library so that implementation is completely up to the user.
The IResourceLoader implementation must be set via:

`excelExporter.setResourceLoader(resourceLoader);`

prior to calling:

`excelExporter.exportHtml(...)`


A sample implementation is provided in the ../demo/ReportGeneratorExternalCss.java file.

Also - includes the changes from the fusionnx fork which add support for size attributes that have trailing suffixes like 'pt', 'px', '%' etc.,
