### PR TITLE
Fix Pdf generation error due to unsupported char entities

### DIFF
--- a/src/main/java/uk/co/certait/htmlexporter/css/CssStringProperty.java
+++ b/src/main/java/uk/co/certait/htmlexporter/css/CssStringProperty.java
@@ -21,7 +21,8 @@ public enum CssStringProperty {
 	BORDER_STYLE("border-style"), BORDER_TOP_STYLE("border-top-style"), BORDER_BOTTOM_STYLE("border-bottom-style"),
 	BORDER_LEFT_STYLE("border-left-style"), BORDER_RIGHT_STYLE("border-right-style"), BORDER_WIDTH("border-width"),
 	BORDER_TOP_WIDTH("border-top-width"), BORDER_BOTTOM_WIDTH("border-bottom-width"),
-	BORDER_LEFT_WIDTH("border-left-width"), BORDER_RIGHT_WIDTH("border-right-width");
+	BORDER_LEFT_WIDTH("border-left-width"), BORDER_RIGHT_WIDTH("border-right-width"),
+	WRAP_TEXT("wrap-text");
 
 	private String property;
 

--- a/src/main/java/uk/co/certait/htmlexporter/css/Style.java
+++ b/src/main/java/uk/co/certait/htmlexporter/css/Style.java
@@ -48,10 +48,22 @@ public class Style {
 	private Map<CssStringProperty, String> stringProperties;
 	private Map<CssColorProperty, Color> colorProperties;
 
+	private String datePattern;
+
 	public Style() {
 		integerProperties = new HashMap<CssIntegerProperty, Integer>();
 		stringProperties = new HashMap<CssStringProperty, String>();
 		colorProperties = new HashMap<CssColorProperty, Color>();
+	}
+
+	public boolean isEmpty() {
+		return integerProperties.isEmpty() && stringProperties.isEmpty() && colorProperties.isEmpty();
+	}
+
+	public void merge(Style style) {
+		getIntegerProperties().putAll(style.getIntegerProperties());
+		getStringProperties().putAll(style.getStringProperties());
+		getColorProperties().putAll(style.getColorProperties());
 	}
 
 	public void addProperty(CssIntegerProperty property, Integer value) {
@@ -84,6 +96,18 @@ public class Style {
 		return colorProperties;
 	}
 
+	public boolean hasProperty(CssIntegerProperty property) {
+		return integerProperties.get(property) != null;
+	}
+
+	public boolean hasProperty(CssStringProperty property) {
+		return stringProperties.get(property) != null;
+	}
+
+	public boolean hasProperty(CssColorProperty property) {
+		return colorProperties.get(property) != null;
+	}
+
 	public Optional<Integer> getProperty(CssIntegerProperty property) {
 		return Optional.ofNullable(integerProperties.get(property));
 	}
@@ -103,7 +127,7 @@ public class Style {
 	public boolean isWidthSet() {
 		return integerProperties.containsKey(CssIntegerProperty.WIDTH);
 	}
-	
+
 	public boolean isFontNameSet() {
 		return stringProperties.containsKey(CssStringProperty.FONT_FAMILY);
 	}
@@ -156,6 +180,18 @@ public class Style {
 		return colorProperties.containsKey(CssColorProperty.COLOR);
 	}
 
+	public boolean isWrapText() {
+		return "true".equals(stringProperties.get(CssStringProperty.WRAP_TEXT));
+	}
+
+	public void setDatePattern(String datePattern) {
+		this.datePattern = datePattern;
+	}
+
+	public String getDatePattern() {
+		return datePattern;
+	}
+
 	@Override
 	public boolean equals(Object obj) {
 		boolean equals = false;
@@ -166,7 +202,8 @@ public class Style {
 			Style other = (Style) obj;
 			equals = new EqualsBuilder().append(this.integerProperties, other.integerProperties)
 					.append(this.stringProperties, other.stringProperties)
-					.append(this.colorProperties, other.colorProperties).isEquals();
+					.append(this.colorProperties, other.colorProperties)
+					.append(this.datePattern, other.datePattern).isEquals();
 		}
 
 		return equals;
@@ -174,7 +211,7 @@ public class Style {
 
 	@Override
 	public int hashCode() {
-		return new HashCodeBuilder(17, 37).append(integerProperties).append(stringProperties).append(colorProperties)
+		return new HashCodeBuilder(17, 37).append(integerProperties).append(stringProperties).append(colorProperties).append(datePattern)
 				.toHashCode();
 	}
 }

--- a/src/main/java/uk/co/certait/htmlexporter/pdf/PdfExporter.java
+++ b/src/main/java/uk/co/certait/htmlexporter/pdf/PdfExporter.java
@@ -20,6 +20,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -55,7 +56,7 @@ public class PdfExporter {
 
 	private void exportHtml(String html, OutputStream out) throws Exception {
 		DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
-		Document doc = builder.parse(new ByteArrayInputStream(html.replaceAll("&nbsp;", "").getBytes()));
+		Document doc = builder.parse(new ByteArrayInputStream(html.replaceAll("&nbsp;", "").getBytes(StandardCharsets.UTF_8)));
 
 		ITextRenderer renderer = new ITextRenderer();
 		renderer.setDocument(doc, null);

--- a/src/main/java/uk/co/certait/htmlexporter/pdf/PdfExporter.java
+++ b/src/main/java/uk/co/certait/htmlexporter/pdf/PdfExporter.java
@@ -21,8 +21,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -56,7 +55,8 @@ public class PdfExporter {
 
 	private void exportHtml(String html, OutputStream out) throws Exception {
 		DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
-		Document doc = builder.parse(new ByteArrayInputStream(html.replaceAll("&nbsp;", "").getBytes(StandardCharsets.UTF_8)));
+		String fixedHtml = fixCharEntities(html);
+		Document doc = builder.parse(new ByteArrayInputStream(fixedHtml.getBytes(StandardCharsets.UTF_8)));
 
 		ITextRenderer renderer = new ITextRenderer();
 		renderer.setDocument(doc, null);
@@ -70,4 +70,121 @@ public class PdfExporter {
 		out.flush();
 		out.close();
 	}
+
+	private static final Map<String, String> charToNumericEntities;
+
+	static {
+		Map<String, String> tempMap = new HashMap<>();
+		tempMap.put("&nbsp;", "&#160;");
+		tempMap.put("&iexcl;", "&#161;");
+		tempMap.put("&cent;", "&#162;");
+		tempMap.put("&pound;", "&#163;");
+		tempMap.put("&curren;", "&#164;");
+		tempMap.put("&yen;", "&#165;");
+		tempMap.put("&brvbar;", "&#166;");
+		tempMap.put("&sect;", "&#167;");
+		tempMap.put("&uml;", "&#168;");
+		tempMap.put("&copy;", "&#169;");
+		tempMap.put("&ordf;", "&#170;");
+		tempMap.put("&laquo;", "&#171;");
+		tempMap.put("&not;", "&#172;");
+		tempMap.put("&shy;", "&#173;");
+		tempMap.put("&reg;", "&#174;");
+		tempMap.put("&macr;", "&#175;");
+		tempMap.put("&deg;", "&#176;");
+		tempMap.put("&plusmn;", "&#177;");
+		tempMap.put("&sup2;", "&#178;");
+		tempMap.put("&sup3;", "&#179;");
+		tempMap.put("&acute;", "&#180;");
+		tempMap.put("&micro;", "&#181;");
+		tempMap.put("&para;", "&#182;");
+		tempMap.put("&middot;", "&#183;");
+		tempMap.put("&cedil;", "&#184;");
+		tempMap.put("&sup1;", "&#185;");
+		tempMap.put("&ordm;", "&#186;");
+		tempMap.put("&raquo;", "&#187;");
+		tempMap.put("&frac14;", "&#188;");
+		tempMap.put("&frac12;", "&#189;");
+		tempMap.put("&frac34;", "&#190;");
+		tempMap.put("&iquest;", "&#191;");
+		tempMap.put("&Agrave;", "&#192;");
+		tempMap.put("&Aacute;", "&#193;");
+		tempMap.put("&Acirc;", "&#194;");
+		tempMap.put("&Atilde;", "&#195;");
+		tempMap.put("&Auml;", "&#196;");
+		tempMap.put("&Aring;", "&#197;");
+		tempMap.put("&AElig;", "&#198;");
+		tempMap.put("&Ccedil;", "&#199;");
+		tempMap.put("&Egrave;", "&#200;");
+		tempMap.put("&Eacute;", "&#201;");
+		tempMap.put("&Ecirc;", "&#202;");
+		tempMap.put("&Euml;", "&#203;");
+		tempMap.put("&Igrave;", "&#204;");
+		tempMap.put("&Iacute;", "&#205;");
+		tempMap.put("&Icirc;", "&#206;");
+		tempMap.put("&Iuml;", "&#207;");
+		tempMap.put("&ETH;", "&#208;");
+		tempMap.put("&Ntilde;", "&#209;");
+		tempMap.put("&Ograve;", "&#210;");
+		tempMap.put("&Oacute;", "&#211;");
+		tempMap.put("&Ocirc;", "&#212;");
+		tempMap.put("&Otilde;", "&#213;");
+		tempMap.put("&Ouml;", "&#214;");
+		tempMap.put("&times;", "&#215;");
+		tempMap.put("&Oslash;", "&#216;");
+		tempMap.put("&Ugrave;", "&#217;");
+		tempMap.put("&Uacute;", "&#218;");
+		tempMap.put("&Ucirc;", "&#219;");
+		tempMap.put("&Uuml;", "&#220;");
+		tempMap.put("&Yacute;", "&#221;");
+		tempMap.put("&THORN;", "&#222;");
+		tempMap.put("&szlig;", "&#223;");
+		tempMap.put("&agrave;", "&#224;");
+		tempMap.put("&aacute;", "&#225;");
+		tempMap.put("&acirc;", "&#226;");
+		tempMap.put("&atilde;", "&#227;");
+		tempMap.put("&auml;", "&#228;");
+		tempMap.put("&aring;", "&#229;");
+		tempMap.put("&aelig;", "&#230;");
+		tempMap.put("&ccedil;", "&#231;");
+		tempMap.put("&egrave;", "&#232;");
+		tempMap.put("&eacute;", "&#233;");
+		tempMap.put("&ecirc;", "&#234;");
+		tempMap.put("&euml;", "&#235;");
+		tempMap.put("&igrave;", "&#236;");
+		tempMap.put("&iacute;", "&#237;");
+		tempMap.put("&icirc;", "&#238;");
+		tempMap.put("&iuml;", "&#239;");
+		tempMap.put("&eth;", "&#240;");
+		tempMap.put("&ntilde;", "&#241;");
+		tempMap.put("&ograve;", "&#242;");
+		tempMap.put("&oacute;", "&#243;");
+		tempMap.put("&ocirc;", "&#244;");
+		tempMap.put("&otilde;", "&#245;");
+		tempMap.put("&ouml;", "&#246;");
+		tempMap.put("&divide;", "&#247;");
+		tempMap.put("&oslash;", "&#248;");
+		tempMap.put("&ugrave;", "&#249;");
+		tempMap.put("&uacute;", "&#250;");
+		tempMap.put("&ucirc;", "&#251;");
+		tempMap.put("&uuml;", "&#252;");
+		tempMap.put("&yacute;", "&#253;");
+		tempMap.put("&thorn;", "&#254;");
+		tempMap.put("&yuml;", "&#255;");
+		charToNumericEntities = Collections.unmodifiableMap(tempMap);
+	}
+
+	/**
+	 * Converts character entities to numeric entities.
+	 *
+	 * @param html
+	 * @return
+	 */
+	private String fixCharEntities(String html) {
+		for(String key:charToNumericEntities.keySet()) {
+			html = html.replace(key, charToNumericEntities.get(key));
+		}
+		return html;
+	}
+
 }

--- a/src/main/java/uk/co/certait/htmlexporter/pdf/PdfExporter.java
+++ b/src/main/java/uk/co/certait/htmlexporter/pdf/PdfExporter.java
@@ -20,6 +20,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -28,6 +30,18 @@ import org.w3c.dom.Document;
 import org.xhtmlrenderer.pdf.ITextRenderer;
 
 public class PdfExporter {
+
+	protected List<String> fontPaths;
+
+	public void registerFontPath(String path) {
+		getFontPaths().add(path);
+	}
+
+	public List<String> getFontPaths() {
+		if(fontPaths == null) fontPaths = new ArrayList<>();
+		return fontPaths;
+	}
+
 	public byte[] exportHtml(String html) throws Exception {
 		ByteArrayOutputStream out = new ByteArrayOutputStream();
 		exportHtml(html, out);
@@ -46,9 +60,9 @@ public class PdfExporter {
 		ITextRenderer renderer = new ITextRenderer();
 		renderer.setDocument(doc, null);
 
-		// FIXME
-		// renderer.getFontResolver().addFont("C:/Windows/Fonts/CALIBRI.TTF",
-		// true);
+		for(String path : getFontPaths()) {
+			renderer.getFontResolver().addFont(path, true);
+		}
 
 		renderer.layout();
 		renderer.createPDF(out);

--- a/src/main/java/uk/co/certait/htmlexporter/writer/AbstractExporter.java
+++ b/src/main/java/uk/co/certait/htmlexporter/writer/AbstractExporter.java
@@ -30,9 +30,21 @@ import uk.co.certait.htmlexporter.css.StyleMap;
 import uk.co.certait.htmlexporter.css.StyleParser;
 
 public abstract class AbstractExporter implements Exporter {
+	protected String datePattern = "yyyy-MM-dd";
 
 	private static final String DATA_NEW_SHEET_ATTRIBUTE = "data-new-sheet";
 	private static final String DATA_SHEET_NAME_ATTRIBUTE = "data-sheet-name";
+
+	protected Document document;
+
+	protected Document parse(String html) {
+		document = Jsoup.parse(html);
+		return document;
+	}
+
+	protected Document getDocument() {
+		return document;
+	}
 
 	public byte[] exportHtml(String html) throws IOException {
 		ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -46,16 +58,22 @@ public abstract class AbstractExporter implements Exporter {
 		exportHtml(html, out);
 	}
 
-	protected Elements getTables(String html) {
-		Document document = Jsoup.parse(html);// FIXME parsing twice
+	public void setDatePattern(String datePattern) {
+		this.datePattern = datePattern;
+	}
 
+	public String getDatePattern() {
+		return this.datePattern;
+	}
+
+	protected Elements getTables() {
+		Document document = getDocument();
 		return document.getElementsByTag("table");
 	}
 
-	protected StyleMap getStyleMapper(String html) {
-		Document document = Jsoup.parse(html);
-		Elements styles = document.getElementsByTag("style");// FIXME parsing
-																// twice
+	protected StyleMap getStyleMapper() {
+		Document document = getDocument();
+		Elements styles = document.getElementsByTag("style");
 
 		StyleParser parser = new StyleParser();
 		StyleMap mapper = new StyleMap(parser.parseStyleSheets(styles));

--- a/src/main/java/uk/co/certait/htmlexporter/writer/AbstractTableRowWriter.java
+++ b/src/main/java/uk/co/certait/htmlexporter/writer/AbstractTableRowWriter.java
@@ -26,6 +26,10 @@ public abstract class AbstractTableRowWriter implements TableRowWriter {
 		rowTracker = new RowTracker();
 	}
 
+	protected TableCellWriter getCellWriter() {
+		return cellWriter;
+	}
+
 	public void writeRow(Element row, int rowIndex) {
 		renderRow(row, rowIndex);
 

--- a/src/main/java/uk/co/certait/htmlexporter/writer/excel/ExcelStyleGenerator.java
+++ b/src/main/java/uk/co/certait/htmlexporter/writer/excel/ExcelStyleGenerator.java
@@ -50,6 +50,11 @@ public class ExcelStyleGenerator {
 
 	static {
 		BORDER_STYLE_MAP.put(new BorderMappingKey("solid", null), BorderStyle.THIN);
+		BORDER_STYLE_MAP.put(new BorderMappingKey("solid", "1px"), BorderStyle.THIN);
+		BORDER_STYLE_MAP.put(new BorderMappingKey("solid", "2px"), BorderStyle.MEDIUM);
+		BORDER_STYLE_MAP.put(new BorderMappingKey("solid", "3px"), BorderStyle.MEDIUM);
+		BORDER_STYLE_MAP.put(new BorderMappingKey("solid", "4px"), BorderStyle.THICK);
+		BORDER_STYLE_MAP.put(new BorderMappingKey("solid", "5px"), BorderStyle.THICK);
 		BORDER_STYLE_MAP.put(new BorderMappingKey("solid", "thin"), BorderStyle.THIN);
 		BORDER_STYLE_MAP.put(new BorderMappingKey("solid", "medium"), BorderStyle.MEDIUM);
 		BORDER_STYLE_MAP.put(new BorderMappingKey("solid", "thick"), BorderStyle.THICK);
@@ -97,6 +102,8 @@ public class ExcelStyleGenerator {
 			dataFormat = createHelper.createDataFormat().getFormat(element.attr(DATE_CELL_ATTRIBUTE));
 		} else if (element.hasAttr(DATA_NUMERIC_CELL_FORMAT_ATTRIBUTE)) {
 			dataFormat = createHelper.createDataFormat().getFormat(element.attr(DATA_NUMERIC_CELL_FORMAT_ATTRIBUTE));
+		} else if(style.getDatePattern() != null && !style.getDatePattern().trim().isEmpty()) {
+			dataFormat = createHelper.createDataFormat().getFormat(style.getDatePattern());
 		}
 
 		StyleCacheKey styleCacheKey = new StyleCacheKey(style, dataFormat);
@@ -110,7 +117,8 @@ public class ExcelStyleGenerator {
 			applyBorders(style, cellStyle);
 			applyFont(cell, style, cellStyle);
 			applyHorizontalAlignment(style, cellStyle);
-			applyverticalAlignment(style, cellStyle);
+			applyVerticalAlignment(style, cellStyle);
+			applyParagraph(style, cellStyle);
 			applyWidth(cell, style);
 
 			if (dataFormat > -1) {
@@ -210,13 +218,19 @@ public class ExcelStyleGenerator {
 		}
 	}
 
-	protected void applyverticalAlignment(Style style, XSSFCellStyle cellStyle) {
+	protected void applyVerticalAlignment(Style style, XSSFCellStyle cellStyle) {
 		if (style.isVerticallyAlignedTop()) {
 			cellStyle.setVerticalAlignment(VerticalAlignment.TOP);
 		} else if (style.isVerticallyAlignedBottom()) {
 			cellStyle.setVerticalAlignment(VerticalAlignment.BOTTOM);
 		} else if (style.isVerticallyAlignedMiddle()) {
 			cellStyle.setVerticalAlignment(VerticalAlignment.CENTER);
+		}
+	}
+
+	protected void applyParagraph(Style style, XSSFCellStyle cellStyle) {
+		if (style.isWrapText()) {
+			cellStyle.setWrapText(true);
 		}
 	}
 

--- a/src/main/java/uk/co/certait/htmlexporter/writer/excel/ExcelTableCellWriter.java
+++ b/src/main/java/uk/co/certait/htmlexporter/writer/excel/ExcelTableCellWriter.java
@@ -79,6 +79,9 @@ public class ExcelTableCellWriter extends AbstractTableCellWriter {
 		} else if(isPossibleDateCell(element) && (dateValue = getDateValue(element, getDatePattern())) != null) {
 			cell.setCellValue(dateValue);
 			datePattern = getDatePattern();
+		} else if(isPossibleDateTimeCell(element) && (dateValue = getDateTimeValue(element, getDateTimePattern())) != null) {
+			cell.setCellValue(dateValue);
+			datePattern = toExcelDateTimePattern(getDateTimePattern());
 		} else if ((numericValue = getNumericValue(element)) != null) {
 			if (isPercentageCell(element)) {
 				cell.setCellValue(numericValue / 100);
@@ -119,4 +122,18 @@ public class ExcelTableCellWriter extends AbstractTableCellWriter {
 
 		new ExcelFunctionCell(cell, range, new ExcelCellRangeResolver(), function);
 	}
+
+	/**
+	 * Converts a date pattern (e.g. from Java) to one that can be used by Excel.
+	 *
+	 * @param dateTimePattern
+	 * @return
+	 */
+	private String toExcelDateTimePattern(String dateTimePattern) {
+		if(dateTimePattern.matches("^.*a$")) { // 1. Replace 'a' at the end of the pattern with AM/PM
+			return dateTimePattern.substring(0, dateTimePattern.lastIndexOf("a")) + "AM/PM";
+		}
+		return dateTimePattern;
+	}
+
 }

--- a/src/main/java/uk/co/certait/htmlexporter/writer/excel/ExcelTableRowWriter.java
+++ b/src/main/java/uk/co/certait/htmlexporter/writer/excel/ExcelTableRowWriter.java
@@ -15,11 +15,14 @@
  */
 package uk.co.certait.htmlexporter.writer.excel;
 
+import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.util.CellRangeAddress;
 import org.apache.poi.xssf.usermodel.XSSFCell;
 import org.jsoup.nodes.Element;
 
+import uk.co.certait.htmlexporter.css.Style;
+import uk.co.certait.htmlexporter.css.StyleMap;
 import uk.co.certait.htmlexporter.writer.AbstractTableRowWriter;
 import uk.co.certait.htmlexporter.writer.TableCellWriter;
 

--- a/src/main/java/uk/co/certait/htmlexporter/writer/ods/OdsExporter.java
+++ b/src/main/java/uk/co/certait/htmlexporter/writer/ods/OdsExporter.java
@@ -36,12 +36,14 @@ public class OdsExporter extends AbstractExporter {
 		try {
 			spreadsheet = SpreadsheetDocument.newSpreadsheetDocument();
 			Table table = spreadsheet.getSheetByIndex(0);
-			;
-			StyleMap styleMapper = getStyleMapper(html);
+
+			parse(html);
+
+			StyleMap styleMapper = getStyleMapper();
 			int startRow = 0;
 			boolean firstLoop = true;
 
-			for (Element element : getTables(html)) {
+			for (Element element : getTables()) {
 
 				if (firstLoop) {
 					String sheetName = getSheetName(element);

--- a/src/test/java/uk/co/certait/htmlexporter/css/StyleParserTest.java
+++ b/src/test/java/uk/co/certait/htmlexporter/css/StyleParserTest.java
@@ -46,7 +46,7 @@ public class StyleParserTest {
 		assertThat(style.isFontBold()).isTrue();
 		assertThat(style.isFontItalic()).isTrue();
 		assertThat(style.isTextUnderlined()).isTrue();
-		assertThat(style.getProperty(CssIntegerProperty.FONT_SIZE).get()).isEqualTo(12);
+		assertThat(style.getProperty(CssIntegerProperty.FONT_SIZE).get()).isEqualTo(9);
 
 		assertThat(styleMap).containsKey("td");
 		style = styleMap.get("td");
@@ -65,7 +65,7 @@ public class StyleParserTest {
 		assertThat(style.isFontBold()).isFalse();
 		assertThat(style.isFontItalic()).isFalse();
 		assertThat(style.isTextUnderlined()).isFalse();
-		assertThat(style.getProperty(CssIntegerProperty.FONT_SIZE).get()).isEqualTo(10);
+		assertThat(style.getProperty(CssIntegerProperty.FONT_SIZE).get()).isEqualTo(7);
 
 		assertThat(styleMap).containsKey(".okay");
 		assertThat(styleMap).containsKey(".warning");
@@ -111,7 +111,7 @@ public class StyleParserTest {
 		assertThat(style.getProperty(CssColorProperty.BACKGROUND_COLOR).get()).isEqualTo(Color.decode("#ff0000"));
 
 		// Specified only in 2nd <style/>
-		assertThat(style.getProperty(CssIntegerProperty.FONT_SIZE).get()).isEqualTo(20);
+		assertThat(style.getProperty(CssIntegerProperty.FONT_SIZE).get()).isEqualTo(15);
 
 		// Property in 1st <Style/> overwritten in 2nd <style/>
 		assertThat(style.getProperty(CssColorProperty.COLOR).get()).isEqualTo(Color.ORANGE);


### PR DESCRIPTION
This pull request includes several enhancements and new features across multiple files in the `htmlexporter` project. The most important changes include adding new CSS properties, improving the `Style` class with new methods, enhancing the `StyleGenerator` with unit conversion, extending the `PdfExporter` to handle custom fonts and character entities, and updating the `AbstractExporter` and `AbstractTableCellWriter` to support date patterns and improved text extraction.

### Enhancements to CSS Handling:

* [`src/main/java/uk/co/certait/htmlexporter/css/CssStringProperty.java`](diffhunk://#diff-97f95201900ab79fa9582b2309afcc4ac7e5ad78865596d00f1c49562b9ecc41L24-R25): Added `WRAP_TEXT` as a new CSS property.
* [`src/main/java/uk/co/certait/htmlexporter/css/Style.java`](diffhunk://#diff-def2bf8583ac765d52547c9ab6e2aa185648e093703a5ba912fb90765693adaaR51-R68): Added methods for checking and merging properties, and handling date patterns. [[1]](diffhunk://#diff-def2bf8583ac765d52547c9ab6e2aa185648e093703a5ba912fb90765693adaaR51-R68) [[2]](diffhunk://#diff-def2bf8583ac765d52547c9ab6e2aa185648e093703a5ba912fb90765693adaaR99-R110) [[3]](diffhunk://#diff-def2bf8583ac765d52547c9ab6e2aa185648e093703a5ba912fb90765693adaaR183-R194) [[4]](diffhunk://#diff-def2bf8583ac765d52547c9ab6e2aa185648e093703a5ba912fb90765693adaaL169-R214)

### Unit Conversion and Pattern Matching:

* [`src/main/java/uk/co/certait/htmlexporter/css/StyleGenerator.java`](diffhunk://#diff-28b9d5ecfdd41a964cc2e4613c1fd38e3526435bba0d643ba7e157ce5bd28bb6R22-R23): Introduced methods for converting various units to points and added regex patterns for font sizes and numbers. [[1]](diffhunk://#diff-28b9d5ecfdd41a964cc2e4613c1fd38e3526435bba0d643ba7e157ce5bd28bb6R22-R23) [[2]](diffhunk://#diff-28b9d5ecfdd41a964cc2e4613c1fd38e3526435bba0d643ba7e157ce5bd28bb6R35-R36) [[3]](diffhunk://#diff-28b9d5ecfdd41a964cc2e4613c1fd38e3526435bba0d643ba7e157ce5bd28bb6R67-L75)

### PDF Export Enhancements:

* [`src/main/java/uk/co/certait/htmlexporter/pdf/PdfExporter.java`](diffhunk://#diff-e5b5f42a422ff5fb5a8676fa60bf2f760e53ff4c52bac8da05277f9f651e0d52R23-R24): Added support for registering custom font paths and converting character entities to numeric entities. [[1]](diffhunk://#diff-e5b5f42a422ff5fb5a8676fa60bf2f760e53ff4c52bac8da05277f9f651e0d52R23-R24) [[2]](diffhunk://#diff-e5b5f42a422ff5fb5a8676fa60bf2f760e53ff4c52bac8da05277f9f651e0d52R33-R44) [[3]](diffhunk://#diff-e5b5f42a422ff5fb5a8676fa60bf2f760e53ff4c52bac8da05277f9f651e0d52L44-R189)

### Date Pattern Support and Improved Text Extraction:

* [`src/main/java/uk/co/certait/htmlexporter/writer/AbstractExporter.java`](diffhunk://#diff-04ab5dfe1cc8c71e1ea8db1d9a16dd3c1edcb94ec32bf2a59c4462e8b31d7425R33-R48): Added support for setting and getting date patterns, and improved HTML parsing. [[1]](diffhunk://#diff-04ab5dfe1cc8c71e1ea8db1d9a16dd3c1edcb94ec32bf2a59c4462e8b31d7425R33-R48) [[2]](diffhunk://#diff-04ab5dfe1cc8c71e1ea8db1d9a16dd3c1edcb94ec32bf2a59c4462e8b31d7425L49-R76)
* [`src/main/java/uk/co/certait/htmlexporter/writer/AbstractTableCellWriter.java`](diffhunk://#diff-f8f7580f1dc6a87754013d965cefcaae00cbb5292d6e444fa28a7b7fbd37fdd5L18-R25): Added regex patterns for date and date-time formats, and improved text extraction from HTML elements. [[1]](diffhunk://#diff-f8f7580f1dc6a87754013d965cefcaae00cbb5292d6e444fa28a7b7fbd37fdd5L18-R25) [[2]](diffhunk://#diff-f8f7580f1dc6a87754013d965cefcaae00cbb5292d6e444fa28a7b7fbd37fdd5R41-R54) [[3]](diffhunk://#diff-f8f7580f1dc6a87754013d965cefcaae00cbb5292d6e444fa28a7b7fbd37fdd5R82-R100) [[4]](diffhunk://#diff-f8f7580f1dc6a87754013d965cefcaae00cbb5292d6e444fa28a7b7fbd37fdd5R110)